### PR TITLE
Refactor Cisco UI into modular Streamlit and add unified dashboard

### DIFF
--- a/cisco_ui/app.py
+++ b/cisco_ui/app.py
@@ -1,0 +1,132 @@
+"""Cisco Streamlit 主介面。"""
+from __future__ import annotations
+
+import streamlit as st
+from streamlit.errors import StreamlitAPIException
+
+try:
+    from streamlit_option_menu import option_menu
+except ModuleNotFoundError:  # pragma: no cover - 選用套件
+    option_menu = None
+
+from . import data_cleaning, log_viewer, model_inference, notifications, visualization
+
+PAGES = {
+    "通知模組": notifications.app,
+    "Log 擷取": log_viewer.app,
+    "模型推論": model_inference.app,
+    "圖表預覽": visualization.app,
+    "資料清理": data_cleaning.app,
+}
+PAGE_EMOJIS = {
+    "通知模組": "🔔",
+    "Log 擷取": "📄",
+    "模型推論": "🔍",
+    "圖表預覽": "📊",
+    "資料清理": "🗑",
+}
+PAGE_ICONS = {
+    "通知模組": "bell",
+    "Log 擷取": "folder",
+    "模型推論": "cpu",
+    "圖表預覽": "bar-chart",
+    "資料清理": "trash",
+}
+PAGE_DESCRIPTIONS = {
+    "通知模組": "管理 Gemini、LINE 與 Discord 推播設定。",
+    "Log 擷取": "監控 ASA log 並自動觸發清洗與推播。",
+    "模型推論": "手動執行全流程 Pipeline。",
+    "圖表預覽": "瀏覽二元與多元分析圖表。",
+    "資料清理": "排程刪除暫存檔案，維持磁碟整潔。",
+}
+
+
+def _configure_page() -> None:
+    try:
+        st.set_page_config(page_title="Cisco D-FLARE 控制中心", page_icon="📡", layout="wide")
+    except StreamlitAPIException:
+        # 在統一介面中可能已設定過 page config，忽略此例外即可。
+        pass
+
+
+def _render_sidebar() -> str:
+    if "cisco_menu_collapse" not in st.session_state:
+        st.session_state["cisco_menu_collapse"] = False
+    sidebar_width = "72px" if st.session_state["cisco_menu_collapse"] else "260px"
+
+    st.markdown(
+        f"""
+        <style>
+        div[data-testid="stSidebar"] {{
+            width: {sidebar_width};
+            background-color: #0f172a;
+            transition: width 0.3s ease;
+        }}
+        div[data-testid="stSidebar"] .nav-link {{
+            color: #e2e8f0;
+        }}
+        div[data-testid="stSidebar"] .nav-link:hover {{
+            background-color: #1e293b;
+        }}
+        div[data-testid="stSidebar"] .nav-link-selected {{
+            background-color: #2563eb;
+            color: #ffffff;
+        }}
+        .menu-collapsed .nav-link span {{
+            display: none;
+        }}
+        .menu-collapsed .nav-link {{
+            justify-content: center;
+        }}
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
+    page_keys = list(PAGES.keys())
+    page_labels = [f"{PAGE_EMOJIS[name]} {name}" for name in page_keys]
+
+    with st.sidebar:
+        st.title("Cisco D-FLARE")
+        st.caption("整合 log 擷取、模型分析與通知的控制中心。")
+        if option_menu:
+            if st.button("☰", key="cisco_menu_toggle"):
+                st.session_state["cisco_menu_collapse"] = not st.session_state["cisco_menu_collapse"]
+            menu_class = "menu-collapsed" if st.session_state["cisco_menu_collapse"] else "menu-expanded"
+            st.markdown(f"<div class='{menu_class}'>", unsafe_allow_html=True)
+            label = option_menu(
+                None,
+                page_labels,
+                icons=[PAGE_ICONS[name] for name in page_keys],
+                menu_icon="list",
+                default_index=0,
+                styles={
+                    "container": {"padding": "0", "background-color": "#0f172a"},
+                    "icon": {"color": "white", "font-size": "16px"},
+                    "nav-link": {
+                        "color": "#cbd5f5",
+                        "font-size": "15px",
+                        "text-align": "left",
+                        "margin": "0px",
+                        "--hover-color": "#1e293b",
+                    },
+                    "nav-link-selected": {"background-color": "#1d4ed8"},
+                },
+            )
+            st.markdown("</div>", unsafe_allow_html=True)
+        else:
+            label = st.radio("功能選單", page_labels)
+
+        selection = page_keys[page_labels.index(label)]
+        st.markdown(PAGE_DESCRIPTIONS.get(selection, ""))
+    return selection
+
+
+def render() -> None:
+    _configure_page()
+    selection = _render_sidebar()
+    PAGES[selection]()
+
+
+if __name__ == "__main__":
+    render()

--- a/cisco_ui/data_cleaning.py
+++ b/cisco_ui/data_cleaning.py
@@ -1,0 +1,169 @@
+"""Cisco 資料清理模組（Streamlit 版）。"""
+from __future__ import annotations
+
+import os
+import threading
+import time
+from datetime import datetime
+from typing import List
+
+import streamlit as st
+
+from .log_viewer import get_log_monitor
+from .utils import append_log
+
+DEFAULT_EXTENSIONS = [".csv", ".png", ".log"]
+
+
+class DataCleaner:
+    """掌管手動與自動清理流程的控制器。"""
+
+    def __init__(self) -> None:
+        self.log_messages: List[str] = []
+        self.extensions: List[str] = DEFAULT_EXTENSIONS.copy()
+        self.auto_thread: threading.Thread | None = None
+        self.stop_event = threading.Event()
+        self.running = False
+        self.cleaning_lock = threading.Lock()
+
+    def _validate_folder(self, folder: str) -> bool:
+        if not folder:
+            append_log(self.log_messages, "❗ 請先設定資料夾路徑")
+            return False
+        if not os.path.isdir(folder):
+            append_log(self.log_messages, f"❌ 資料夾不存在：{folder}")
+            return False
+        return True
+
+    def start_auto(self, folder: str, retention: int, interval: int) -> None:
+        if self.running:
+            append_log(self.log_messages, "⚠️ 自動清理已啟動")
+            return
+        if not self._validate_folder(folder):
+            return
+        self.stop_event.clear()
+        self.running = True
+        monitor = get_log_monitor()
+        self.auto_thread = threading.Thread(
+            target=self._auto_loop,
+            args=(folder, retention, interval, monitor),
+            daemon=True,
+        )
+        self.auto_thread.start()
+        append_log(self.log_messages, f"🟢 自動清理啟動，每 {interval} 小時執行一次")
+
+    def stop_auto(self) -> None:
+        if not self.running:
+            append_log(self.log_messages, "ℹ️ 自動清理尚未啟動")
+            return
+        self.stop_event.set()
+        if self.auto_thread and self.auto_thread.is_alive():
+            self.auto_thread.join(timeout=3)
+        self.auto_thread = None
+        self.running = False
+        append_log(self.log_messages, "⛔ 自動清理已停止")
+
+    def _auto_loop(self, folder: str, retention: int, interval: int, monitor) -> None:
+        while not self.stop_event.is_set():
+            self._execute_clean(folder, retention, "auto", monitor)
+            if self.stop_event.wait(interval * 3600):
+                break
+        self.running = False
+
+    def manual_clean(self, folder: str, retention: int) -> None:
+        if not self._validate_folder(folder):
+            return
+        monitor = get_log_monitor()
+        self._execute_clean(folder, retention, "manual", monitor)
+
+    def batch_delete(self, folder: str) -> None:
+        if not self._validate_folder(folder):
+            return
+        monitor = get_log_monitor()
+        self._execute_clean(folder, 0, "batch", monitor)
+
+    def _execute_clean(self, folder: str, retention: int, mode: str, monitor) -> None:
+        if self.cleaning_lock.locked():
+            append_log(self.log_messages, "⏳ 另一個清理流程進行中，請稍候")
+            return
+        with self.cleaning_lock:
+            if monitor:
+                monitor.pause()
+            try:
+                self._clean_folder(folder, retention, mode)
+            finally:
+                if monitor:
+                    monitor.resume()
+
+    def _clean_folder(self, folder: str, retention: int, mode: str) -> None:
+        now = time.time()
+        removed, skipped, failed = [], [], []
+        for name in os.listdir(folder):
+            if not any(name.lower().endswith(ext) for ext in self.extensions):
+                continue
+            path = os.path.join(folder, name)
+            try:
+                age_hours = (now - os.path.getmtime(path)) / 3600
+            except Exception as exc:  # pragma: no cover
+                failed.append(f"{name}（讀取時間失敗：{exc}")
+                continue
+            need_remove = mode == "batch" or age_hours > retention
+            if need_remove:
+                try:
+                    os.remove(path)
+                    removed.append(name)
+                except Exception as exc:  # pragma: no cover
+                    failed.append(f"{name}（刪除失敗：{exc}")
+            else:
+                skipped.append(name)
+        summary = (
+            f"模式：{mode}｜刪除 {len(removed)} 筆，保留 {len(skipped)} 筆，失敗 {len(failed)} 筆"
+        )
+        append_log(self.log_messages, summary)
+        if removed:
+            append_log(self.log_messages, f"已刪除：{removed}")
+        if failed:
+            append_log(self.log_messages, f"發生錯誤：{failed}")
+        append_log(self.log_messages, f"完成時間：{datetime.now():%Y-%m-%d %H:%M:%S}")
+
+
+def get_data_cleaner() -> DataCleaner:
+    if "cisco_data_cleaner" not in st.session_state:
+        st.session_state["cisco_data_cleaner"] = DataCleaner()
+    return st.session_state["cisco_data_cleaner"]
+
+
+def app() -> None:
+    """資料清理主頁面。"""
+    cleaner = get_data_cleaner()
+    monitor = get_log_monitor()
+
+    st.title("🗑 資料清理模組")
+    st.markdown("管理清洗資料夾內的暫存檔案，可設定自動清理排程。")
+
+    folder = st.text_input("目標資料夾", value=monitor.settings.get("clean_csv_dir", ""))
+    retention = st.number_input("保留小時數", min_value=1, max_value=168, value=3)
+    interval = st.number_input("自動清理間隔（小時）", min_value=1, max_value=168, value=6)
+
+    ext_input = st.text_input(
+        "清理副檔名（以逗號分隔）",
+        value=",".join(cleaner.extensions),
+        help="例如：.csv,.png,.log",
+    )
+    extensions = [ext.strip() for ext in ext_input.split(",") if ext.strip()]
+    cleaner.extensions = [ext if ext.startswith(".") else f".{ext}" for ext in extensions] or DEFAULT_EXTENSIONS
+
+    col1, col2, col3 = st.columns(3)
+    if cleaner.running:
+        if col1.button("停止自動清理"):
+            cleaner.stop_auto()
+    else:
+        if col1.button("啟動自動清理"):
+            cleaner.start_auto(folder, int(retention), int(interval))
+    if col2.button("立即手動清理"):
+        cleaner.manual_clean(folder, int(retention))
+    if col3.button("批次清空所有檔案"):
+        cleaner.batch_delete(folder)
+
+    st.markdown("### 清理日誌")
+    st.text_area("清理狀態", value="\n".join(cleaner.log_messages), height=280)

--- a/cisco_ui/log_viewer.py
+++ b/cisco_ui/log_viewer.py
@@ -1,0 +1,398 @@
+"""Cisco 版本的 Log 監聽與自動清洗模組（Streamlit 版）。
+
+此模組將原本集中於 PyQt5 介面的程式碼重構為 Streamlit 相容的寫法，
+完整保留自動監聽、資料清洗、模型推論與通知串接的功能，並補強
+執行緒控管與日誌呈現，方便在網頁化介面中維護與擴充。
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import threading
+import time
+from typing import Dict, List, Optional, Set, Tuple
+
+import pandas as pd
+import streamlit as st
+
+from Cisco_ui_app_bundle import D_FLAREsys
+from Cisco_ui_app_bundle.D_FLARE_Notification import notification_pipeline
+
+from .utils import append_log, load_json, save_json
+
+# 設定檔路徑與預設值定義
+LOG_SETTINGS_FILE = "logfetcher_settings.json"
+NOTIFIER_SETTINGS_FILE = "notifier_settings.txt"
+DEFAULT_LOG_SETTINGS = {
+    "save_dir": "",
+    "binary_model_path": "",
+    "model_path": "",
+    "clean_csv_dir": "",
+}
+DEFAULT_NOTIFIER_SETTINGS = {
+    "gemini_api_key": "",
+    "line_channel_secret": "",
+    "line_channel_access_token": "",
+    "line_webhook_url": "",
+    "discord_webhook_url": "",
+}
+
+
+class LogMonitor:
+    """負責維護資料夾監控狀態與自動清洗流程的核心物件。"""
+
+    def __init__(self) -> None:
+        self.settings: Dict[str, str] = load_json(LOG_SETTINGS_FILE, DEFAULT_LOG_SETTINGS)
+        self.log_messages: List[str] = []
+        self.listening = False
+        self.stop_event = threading.Event()
+        self.monitor_thread: Optional[threading.Thread] = None
+        self.socket_process: Optional[subprocess.Popen[str]] = None
+        self.processed_files: Set[Tuple[str, int, float]] = set()
+        self.notified_multiclass_files: Set[str] = set()
+        self.last_file_checked = ""
+        self.last_file_size = 0
+        self.file_stable_count = 0
+        self.last_processed_file = ""
+        self.cleaning_lock = threading.Lock()
+        self.latest_result: Optional[Dict[str, object]] = None
+        self.paused = False
+        self._last_folder_error: Optional[str] = None
+
+    # ==== 狀態管理 ====
+    def update_settings(self, **kwargs: str) -> None:
+        """更新監控設定並立即寫入設定檔。"""
+        self.settings.update({k: v.strip() for k, v in kwargs.items()})
+        save_json(LOG_SETTINGS_FILE, self.settings)
+        append_log(self.log_messages, "✅ 監控設定已儲存")
+
+    def start_listening(self) -> None:
+        """啟動資料夾監控與背景掃描執行緒。"""
+        if self.listening:
+            append_log(self.log_messages, "⚠️ 監聽已在執行中")
+            return
+
+        required = {
+            "log 儲存資料夾": self.settings.get("save_dir", ""),
+            "二元模型路徑": self.settings.get("binary_model_path", ""),
+            "多元模型路徑": self.settings.get("model_path", ""),
+            "清洗輸出資料夾": self.settings.get("clean_csv_dir", ""),
+        }
+        missing = [label for label, value in required.items() if not value]
+        if missing:
+            append_log(self.log_messages, f"❗ 缺少必要設定：{'、'.join(missing)}")
+            return
+
+        save_dir = required["log 儲存資料夾"]
+        if not os.path.exists(save_dir):
+            append_log(self.log_messages, f"❌ 監控資料夾不存在：{save_dir}")
+            return
+        if not os.access(save_dir, os.W_OK):
+            append_log(self.log_messages, f"❌ 無法寫入監控資料夾：{save_dir}")
+            return
+
+        self.stop_event.clear()
+        self.monitor_thread = threading.Thread(target=self._monitor_loop, daemon=True)
+        self.monitor_thread.start()
+        self.listening = True
+        append_log(self.log_messages, f"🟢 已啟動監聽，路徑：{save_dir}")
+        self._start_socket_process(save_dir)
+
+    def _start_socket_process(self, save_dir: str) -> None:
+        """若專屬 socket 腳本存在則同步啟動子程序。"""
+        script_path = os.path.join(os.getcwd(), "socket_5.py")
+        if not os.path.exists(script_path):
+            append_log(self.log_messages, "ℹ️ 找不到 socket_5.py，僅啟動資料夾監控。")
+            return
+        try:
+            self.socket_process = subprocess.Popen(
+                [sys.executable, script_path, save_dir],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+            append_log(self.log_messages, "🚀 已啟動 socket_5.py 子程序")
+            threading.Thread(target=self._capture_socket_output, daemon=True).start()
+        except Exception as exc:
+            append_log(self.log_messages, f"❌ 無法啟動 socket 子程序：{exc}")
+            self.socket_process = None
+
+    def _capture_socket_output(self) -> None:
+        """持續讀取 socket 子程序輸出並記錄於日誌。"""
+        if not self.socket_process or not self.socket_process.stdout:
+            return
+        for line in self.socket_process.stdout:
+            line = line.strip()
+            if line:
+                append_log(self.log_messages, f"[socket] {line}")
+        append_log(self.log_messages, "🛑 socket 子程序已結束")
+
+    def stop_listening(self) -> None:
+        """停止監控與所有背景工作。"""
+        if not self.listening:
+            append_log(self.log_messages, "⚠️ 尚未啟動監聽")
+            return
+        self.stop_event.set()
+        if self.monitor_thread and self.monitor_thread.is_alive():
+            self.monitor_thread.join(timeout=3)
+        self.monitor_thread = None
+        self.listening = False
+        append_log(self.log_messages, "⛔ 已停止監聽")
+
+        if self.socket_process:
+            try:
+                self.socket_process.terminate()
+                self.socket_process.wait(timeout=3)
+                append_log(self.log_messages, "🛑 socket 子程序已終止")
+            except Exception as exc:
+                append_log(self.log_messages, f"⚠️ socket 子程序終止失敗：{exc}")
+            finally:
+                self.socket_process = None
+
+    # ==== 資料夾掃描邏輯 ====
+    def _monitor_loop(self) -> None:
+        """背景執行緒：每 5 秒掃描一次資料夾。"""
+        while not self.stop_event.is_set():
+            if not self.paused:
+                self._inspect_folder()
+            time.sleep(5)
+
+    def _inspect_folder(self, manual: bool = False) -> None:
+        """掃描資料夾，若找到穩定的最新檔案便啟動自動清洗。"""
+        folder = self.settings.get("save_dir", "").strip()
+        if not folder:
+            if manual:
+                append_log(self.log_messages, "⚠️ 請先設定 log 儲存資料夾")
+            return
+        if not os.path.isdir(folder):
+            if manual or self._last_folder_error != folder:
+                append_log(self.log_messages, f"❗ 監控資料夾不存在：{folder}")
+                self._last_folder_error = folder
+            return
+        self._last_folder_error = None
+
+        try:
+            files = [
+                f
+                for f in os.listdir(folder)
+                if f.endswith(".csv") and f.startswith("asa_logs_") and "_result" not in f
+            ]
+        except Exception as exc:
+            append_log(self.log_messages, f"❌ 無法讀取資料夾：{exc}")
+            return
+
+        if not files:
+            if manual:
+                append_log(self.log_messages, "ℹ️ 目前資料夾沒有新的 log 檔案")
+            return
+
+        files.sort(key=lambda name: os.path.getmtime(os.path.join(folder, name)), reverse=True)
+        latest_file = os.path.join(folder, files[0])
+        current_size = os.path.getsize(latest_file) if os.path.exists(latest_file) else 0
+        now = time.time()
+
+        # 移除超過一小時的紀錄
+        self.processed_files = {
+            item for item in self.processed_files if now - item[2] < 3600
+        }
+        if any(item[0] == latest_file and item[1] == current_size for item in self.processed_files):
+            return
+
+        if latest_file != self.last_file_checked:
+            self.last_file_checked = latest_file
+            self.last_file_size = current_size
+            self.file_stable_count = 1
+            append_log(self.log_messages, f"🆕 偵測到新檔案：{latest_file}，等待大小穩定")
+            return
+
+        if current_size == self.last_file_size:
+            self.file_stable_count += 1
+            append_log(self.log_messages, f"📈 檔案大小連續第 {self.file_stable_count} 次穩定：{current_size} bytes")
+        else:
+            self.file_stable_count = 1
+            self.last_file_size = current_size
+            append_log(self.log_messages, f"🔁 檔案大小變動為 {current_size}，重新計數")
+            return
+
+        if self.file_stable_count >= 2:
+            self.last_processed_file = latest_file
+            self.processed_files.add((latest_file, current_size, now))
+            append_log(self.log_messages, f"🚀 檔案穩定，準備自動分析：{latest_file}")
+            self._launch_auto_clean(latest_file)
+
+    def scan_once(self) -> None:
+        """供 UI 手動觸發一次資料夾掃描。"""
+        append_log(self.log_messages, "🔍 手動觸發資料夾掃描")
+        self._inspect_folder(manual=True)
+
+    # ==== 自動清洗與推論 ====
+    def _launch_auto_clean(self, file_path: str) -> None:
+        if self.cleaning_lock.locked():
+            append_log(self.log_messages, "⏳ 前一次自動分析尚未完成，略過本次觸發")
+            return
+        threading.Thread(target=self._run_auto_clean, args=(file_path,), daemon=True).start()
+
+    def _run_auto_clean(self, file_path: str) -> None:
+        with self.cleaning_lock:
+            append_log(self.log_messages, "⚙️ 開始執行自動清洗與推論流程")
+            binary_model = self.settings.get("binary_model_path", "").strip()
+            multi_model = self.settings.get("model_path", "").strip()
+            output_dir = self.settings.get("clean_csv_dir", "").strip()
+
+            missing = []
+            if not binary_model:
+                missing.append("二元模型")
+            if not multi_model:
+                missing.append("多元模型")
+            if not output_dir:
+                missing.append("清洗輸出資料夾")
+            if not os.path.exists(file_path):
+                missing.append("log 檔案")
+            if missing:
+                append_log(self.log_messages, f"❌ 自動分析缺少必要項目：{'、'.join(missing)}")
+                return
+
+            os.makedirs(output_dir, exist_ok=True)
+
+            try:
+                result = D_FLAREsys.dflare_sys_full_pipeline(
+                    raw_log_path=file_path,
+                    binary_model_path=binary_model,
+                    multiclass_model_path=multi_model,
+                    output_dir=output_dir,
+                    show_progress=False,
+                )
+                self.latest_result = result
+                append_log(
+                    self.log_messages,
+                    f"✅ 自動分析完成，輸出 CSV：{result.get('binary_output_csv', '-')}",
+                )
+                if result.get("binary_output_pie"):
+                    append_log(
+                        self.log_messages,
+                        f"📊 二元圓餅圖：{result.get('binary_output_pie')}",
+                    )
+                if result.get("multiclass_output_csv"):
+                    append_log(
+                        self.log_messages,
+                        f"📊 多元結果：{result.get('multiclass_output_csv')}",
+                    )
+                self._handle_auto_notification(result)
+            except Exception as exc:  # pragma: no cover - 盡量避免中斷
+                append_log(self.log_messages, f"❌ 自動分析失敗：{exc}")
+
+    def _handle_auto_notification(self, result: Dict[str, object]) -> None:
+        """根據多元結果啟動通知模組。"""
+        multi_csv = result.get("multiclass_output_csv")
+        if not multi_csv:
+            append_log(self.log_messages, "ℹ️ 本批次無攻擊流量，未產生多元結果")
+            return
+        if not isinstance(multi_csv, str) or not os.path.exists(multi_csv):
+            append_log(self.log_messages, f"⚠️ 找不到多元結果檔案：{multi_csv}")
+            return
+        if multi_csv in self.notified_multiclass_files:
+            append_log(self.log_messages, "ℹ️ 該多元結果已推播過，略過重複通知")
+            return
+
+        try:
+            df = pd.read_csv(multi_csv)
+        except Exception as exc:
+            append_log(self.log_messages, f"❌ 讀取多元結果失敗：{exc}")
+            return
+
+        if "Severity" not in df.columns:
+            append_log(self.log_messages, "ℹ️ 多元結果缺少 Severity 欄位，無法自動推播")
+            return
+        if not df["Severity"].astype(str).isin(["1", "2", "3"]).any():
+            append_log(self.log_messages, "ℹ️ 本批次無高風險事件，未啟動推播")
+            return
+
+        settings = load_json(NOTIFIER_SETTINGS_FILE, DEFAULT_NOTIFIER_SETTINGS)
+        append_log(self.log_messages, "🔔 偵測到高風險事件，啟動通知模組")
+        notification_pipeline(
+            result_csv=multi_csv,
+            gemini_api_key=settings.get("gemini_api_key", ""),
+            line_channel_access_token=settings.get("line_channel_access_token", ""),
+            line_webhook_url=settings.get("line_webhook_url", ""),
+            discord_webhook_url=settings.get("discord_webhook_url", ""),
+            ui_callback=lambda msg: append_log(self.log_messages, msg),
+        )
+        self.notified_multiclass_files.add(multi_csv)
+
+    # ==== 供資料清理模組呼叫的暫停控制 ====
+    def pause(self) -> None:
+        if not self.paused:
+            self.paused = True
+            append_log(self.log_messages, "⏸️ 主流程已暫停，等待資料清理完成")
+
+    def resume(self) -> None:
+        if self.paused:
+            self.paused = False
+            append_log(self.log_messages, "▶️ 主流程已恢復")
+
+    def manual_auto_clean(self, file_path: str) -> None:
+        """供 UI 手動指定檔案並觸發自動分析。"""
+        if not file_path:
+            append_log(self.log_messages, "⚠️ 請輸入要分析的 log 檔案路徑")
+            return
+        if not os.path.exists(file_path):
+            append_log(self.log_messages, f"❌ 指定檔案不存在：{file_path}")
+            return
+        self.last_processed_file = file_path
+        self._launch_auto_clean(file_path)
+
+
+def get_log_monitor() -> LogMonitor:
+    """取得儲存在 Streamlit session 中的 LogMonitor 單例。"""
+    if "cisco_log_monitor" not in st.session_state:
+        st.session_state["cisco_log_monitor"] = LogMonitor()
+    return st.session_state["cisco_log_monitor"]
+
+
+def app() -> None:
+    """Streamlit 版的 Log 擷取頁面。"""
+    monitor = get_log_monitor()
+
+    st.title("📄 Cisco Log 擷取與自動分析")
+    st.markdown("此頁面負責監控 ASA log、執行資料清洗與自動推播。")
+
+    with st.form("log_settings"):
+        save_dir = st.text_input("log 儲存資料夾", value=monitor.settings.get("save_dir", ""))
+        binary_model = st.text_input("二元模型檔案路徑", value=monitor.settings.get("binary_model_path", ""))
+        multi_model = st.text_input("多元模型檔案路徑", value=monitor.settings.get("model_path", ""))
+        clean_dir = st.text_input("清洗輸出資料夾", value=monitor.settings.get("clean_csv_dir", ""))
+        submitted = st.form_submit_button("💾 儲存設定")
+        if submitted:
+            monitor.update_settings(
+                save_dir=save_dir,
+                binary_model_path=binary_model,
+                model_path=multi_model,
+                clean_csv_dir=clean_dir,
+            )
+
+    col1, col2, col3 = st.columns(3)
+    if col1.button("▶️ 啟動監聽"):
+        monitor.start_listening()
+    if col2.button("⏹️ 停止監聽"):
+        monitor.stop_listening()
+    if col3.button("🔁 手動掃描一次"):
+        monitor.scan_once()
+
+    manual_file = st.text_input("手動指定要分析的 log 檔案路徑", value=monitor.last_processed_file)
+    if st.button("⚙️ 立即執行自動分析"):
+        monitor.manual_auto_clean(manual_file)
+
+    st.markdown("### 監控狀態")
+    status = "🟢 監聽中" if monitor.listening else "⛔ 已停止"
+    st.write(f"目前狀態：{status}")
+    if monitor.latest_result:
+        st.success("顯示最新自動分析結果：")
+        st.json(monitor.latest_result)
+
+    st.markdown("### 執行日誌")
+    st.text_area(
+        "Log output",
+        value="\n".join(monitor.log_messages),
+        height=320,
+    )

--- a/cisco_ui/model_inference.py
+++ b/cisco_ui/model_inference.py
@@ -1,0 +1,107 @@
+"""Cisco 模型推論頁面模組。"""
+from __future__ import annotations
+
+import os
+import tempfile
+from typing import Optional
+
+import pandas as pd
+import streamlit as st
+
+from Cisco_ui_app_bundle import D_FLAREsys
+from Cisco_ui_app_bundle.D_FLARE_Notification import notification_pipeline
+
+from .log_viewer import get_log_monitor
+from .utils import load_json
+
+NOTIFIER_SETTINGS_FILE = "notifier_settings.txt"
+
+
+def _write_temp_file(upload, suffix: str) -> Optional[str]:
+    """將上傳檔案寫入暫存檔，回傳實際路徑。"""
+    if upload is None:
+        return None
+    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+        tmp.write(upload.getbuffer())
+        return tmp.name
+
+
+def app() -> None:
+    """提供手動執行完整 Pipeline 的頁面。"""
+    st.title("🔍 Cisco 模型推論與批次分析")
+    st.markdown("可手動選擇原始 log 檔與模型，立即執行 Cisco ASA 全流程分析。")
+
+    monitor = get_log_monitor()
+    default_output = monitor.settings.get("clean_csv_dir", "")
+
+    st.markdown("#### 1. 選擇輸入檔案")
+    upload_log = st.file_uploader("上傳原始 log (CSV/TXT/GZ)", type=["csv", "txt", "gz"])
+    manual_log_path = st.text_input("或輸入既有 log 路徑", value=monitor.last_processed_file)
+
+    st.markdown("#### 2. 模型設定")
+    upload_binary = st.file_uploader("上傳二元模型 (.pkl)", type=["pkl"], key="binary_upload")
+    manual_binary_path = st.text_input("或輸入二元模型路徑", value=monitor.settings.get("binary_model_path", ""))
+
+    upload_multi = st.file_uploader("上傳多元模型 (.pkl)", type=["pkl"], key="multi_upload")
+    manual_multi_path = st.text_input("或輸入多元模型路徑", value=monitor.settings.get("model_path", ""))
+
+    st.markdown("#### 3. 輸出設定")
+    output_dir = st.text_input("輸出資料夾", value=default_output)
+    auto_notify = st.checkbox("自動觸發通知模組", value=True)
+
+    if st.button("🚀 執行 Pipeline"):
+        log_path = _write_temp_file(upload_log, suffix=os.path.splitext(upload_log.name)[1]) if upload_log else manual_log_path
+        binary_path = _write_temp_file(upload_binary, suffix=".pkl") if upload_binary else manual_binary_path
+        multi_path = _write_temp_file(upload_multi, suffix=".pkl") if upload_multi else manual_multi_path
+
+        errors = []
+        if not log_path or not os.path.exists(log_path):
+            errors.append("原始 log")
+        if not binary_path or not os.path.exists(binary_path):
+            errors.append("二元模型")
+        if not multi_path or not os.path.exists(multi_path):
+            errors.append("多元模型")
+        if not output_dir:
+            errors.append("輸出資料夾")
+        if errors:
+            st.error("請確認以下項目：" + "、".join(errors))
+        else:
+            os.makedirs(output_dir, exist_ok=True)
+            try:
+                result = D_FLAREsys.dflare_sys_full_pipeline(
+                    raw_log_path=log_path,
+                    binary_model_path=binary_path,
+                    multiclass_model_path=multi_path,
+                    output_dir=output_dir,
+                    show_progress=False,
+                )
+                st.success("分析完成！")
+                st.json(result)
+                st.session_state["cisco_manual_result"] = result
+
+                multi_csv = result.get("multiclass_output_csv")
+                if multi_csv and os.path.exists(multi_csv):
+                    st.markdown("#### 多元結果預覽")
+                    try:
+                        df_multi = pd.read_csv(multi_csv)
+                        st.dataframe(df_multi.head(50))
+                    except Exception as exc:  # pragma: no cover
+                        st.warning(f"無法讀取多元結果：{exc}")
+
+                if auto_notify:
+                    st.info("自動推播啟動中...")
+                    notifier_settings = load_json(NOTIFIER_SETTINGS_FILE, {})
+                    notification_pipeline(
+                        result_csv=result.get("multiclass_output_csv", ""),
+                        gemini_api_key=notifier_settings.get("gemini_api_key", ""),
+                        line_channel_access_token=notifier_settings.get("line_channel_access_token", ""),
+                        line_webhook_url=notifier_settings.get("line_webhook_url", ""),
+                        discord_webhook_url=notifier_settings.get("discord_webhook_url", ""),
+                        ui_callback=lambda msg: st.write(msg),
+                    )
+            except Exception as exc:  # pragma: no cover
+                st.error(f"執行失敗：{exc}")
+
+    if "cisco_manual_result" in st.session_state:
+        st.markdown("### 最近一次分析結果")
+        st.json(st.session_state["cisco_manual_result"])

--- a/cisco_ui/notifications.py
+++ b/cisco_ui/notifications.py
@@ -1,0 +1,128 @@
+"""Cisco 通知模組（Streamlit 版）。"""
+from __future__ import annotations
+
+import os
+from typing import Dict, List
+
+import streamlit as st
+
+from Cisco_ui_app_bundle.D_FLARE_Notification import send_discord
+
+from .utils import append_log, load_json, save_json
+
+SETTINGS_FILE = "notifier_settings.txt"
+USER_FILE = "line_users.txt"
+LAST_USER_FILE = "last_user.txt"
+DEFAULT_SETTINGS = {
+    "gemini_api_key": "",
+    "line_channel_secret": "",
+    "line_channel_access_token": "",
+    "line_webhook_url": "",
+    "discord_webhook_url": "",
+}
+
+
+def _get_status_buffer() -> List[str]:
+    if "cisco_notifier_logs" not in st.session_state:
+        st.session_state["cisco_notifier_logs"] = []
+    return st.session_state["cisco_notifier_logs"]
+
+
+def _load_settings() -> Dict[str, str]:
+    if "cisco_notifier_settings" not in st.session_state:
+        st.session_state["cisco_notifier_settings"] = load_json(SETTINGS_FILE, DEFAULT_SETTINGS)
+    return st.session_state["cisco_notifier_settings"]
+
+
+def _save_settings(data: Dict[str, str]) -> None:
+    st.session_state["cisco_notifier_settings"] = data
+    save_json(SETTINGS_FILE, data)
+    append_log(_get_status_buffer(), "✅ 設定已儲存")
+
+
+def _get_last_user_id() -> str | None:
+    if os.path.exists(LAST_USER_FILE):
+        with open(LAST_USER_FILE, "r", encoding="utf-8") as handle:
+            content = handle.read().strip()
+            if content:
+                return content
+    if os.path.exists(USER_FILE):
+        with open(USER_FILE, "r", encoding="utf-8") as handle:
+            ids = [line.strip() for line in handle if line.strip()]
+            if ids:
+                return ids[-1]
+    return None
+
+
+def _send_line_test(settings: Dict[str, str]) -> None:
+    buffer = _get_status_buffer()
+    user_id = _get_last_user_id()
+    if not user_id:
+        append_log(buffer, "❌ 找不到 LINE 使用者 ID，請先透過 Bot 綁定")
+        return
+    token = settings.get("line_channel_access_token", "").strip()
+    if not token:
+        append_log(buffer, "❌ 請先設定 LINE Channel Access Token")
+        return
+    try:
+        from linebot.v3.messaging import MessagingApi, Configuration, ApiClient
+        from linebot.v3.messaging.models import TextMessage, PushMessageRequest
+    except Exception as exc:  # pragma: no cover - 無套件環境
+        append_log(buffer, f"❌ 無法載入 LINE SDK：{exc}")
+        return
+    try:
+        config = Configuration(access_token=token)
+        with ApiClient(config) as api_client:
+            line_api = MessagingApi(api_client)
+            msg = TextMessage(text="✅ 已發送 LINE 測試通知 (D-FLARE)")
+            req = PushMessageRequest(to=user_id, messages=[msg])
+            line_api.push_message(push_message_request=req)
+        append_log(buffer, "✅ 已發送 LINE 測試通知")
+    except Exception as exc:  # pragma: no cover
+        append_log(buffer, f"❌ LINE 發送失敗：{exc}")
+
+
+def _send_discord_test(settings: Dict[str, str]) -> None:
+    buffer = _get_status_buffer()
+    url = settings.get("discord_webhook_url", "").strip()
+    if not url:
+        append_log(buffer, "❌ 請先輸入 Discord Webhook URL")
+        return
+    send_discord(url, "💬 D-FLARE 測試通知", callback=lambda msg: append_log(buffer, msg))
+
+
+def app() -> None:
+    """通知模組主畫面。"""
+    st.title("🔔 通知設定與推播")
+    st.markdown("設定 Gemini、LINE 與 Discord 參數，並可立即進行測試推播。")
+
+    settings = _load_settings()
+
+    gemini = st.text_input("Gemini API Key", value=settings.get("gemini_api_key", ""), type="password")
+    line_secret = st.text_input("LINE Channel Secret", value=settings.get("line_channel_secret", ""), type="password")
+    line_token = st.text_input(
+        "LINE Channel Access Token",
+        value=settings.get("line_channel_access_token", ""),
+        type="password",
+    )
+    line_webhook = st.text_input("LINE Webhook URL", value=settings.get("line_webhook_url", ""))
+    discord_url = st.text_input("Discord Webhook URL", value=settings.get("discord_webhook_url", ""))
+
+    if st.button("💾 儲存所有設定"):
+        updated = {
+            "gemini_api_key": gemini,
+            "line_channel_secret": line_secret,
+            "line_channel_access_token": line_token,
+            "line_webhook_url": line_webhook,
+            "discord_webhook_url": discord_url,
+        }
+        _save_settings(updated)
+
+    col1, col2 = st.columns(2)
+    if col1.button("🟩 發送 LINE 測試通知"):
+        _send_line_test(_load_settings())
+    if col2.button("💬 發送 Discord 測試通知"):
+        _send_discord_test(_load_settings())
+
+    st.markdown("### 推播狀態回饋")
+    st.text_area("通知日誌", value="\n".join(_get_status_buffer()), height=260)

--- a/cisco_ui/utils.py
+++ b/cisco_ui/utils.py
@@ -1,0 +1,50 @@
+"""Cisco Streamlit UI 共用工具函式模組。
+
+此模組集中管理設定檔讀寫、日誌紀錄等共用邏輯，
+提供其他子模組呼叫以維持程式碼一致性。所有函式皆附上
+中文註解，方便後續維護與擴充。
+"""
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime
+from typing import Any, Dict, List
+
+LOG_BUFFER_LIMIT = 500
+
+
+def load_json(path: str, default: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    """讀取 JSON 設定檔，若不存在則回傳預設值。"""
+    if default is None:
+        default = {}
+    if os.path.exists(path):
+        try:
+            with open(path, "r", encoding="utf-8") as handle:
+                data = json.load(handle)
+            if isinstance(data, dict):
+                return data
+        except Exception:
+            # 若讀檔失敗則回傳預設值，避免整體流程中斷。
+            pass
+    return dict(default)
+
+
+def save_json(path: str, data: Dict[str, Any]) -> None:
+    """將資料以 JSON 格式寫入指定路徑。"""
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(data, handle, ensure_ascii=False, indent=2)
+
+
+def append_log(buffer: List[str], message: str) -> None:
+    """將訊息附上時間戳記後寫入日誌緩衝區。"""
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    buffer.append(f"[{timestamp}] {message}")
+    if len(buffer) > LOG_BUFFER_LIMIT:
+        del buffer[:-LOG_BUFFER_LIMIT]
+
+
+def ensure_directory(path: str) -> None:
+    """確認資料夾存在，不存在時自動建立。"""
+    if path and not os.path.exists(path):
+        os.makedirs(path, exist_ok=True)

--- a/cisco_ui/visualization.py
+++ b/cisco_ui/visualization.py
@@ -1,0 +1,54 @@
+"""Cisco 圖表預覽模組。"""
+from __future__ import annotations
+
+import os
+from typing import Dict
+
+import streamlit as st
+
+from .log_viewer import get_log_monitor
+
+CHART_FILES: Dict[str, str] = {
+    "二元長條圖": "binary_bar.png",
+    "二元圓餅圖": "binary_pie.png",
+    "多元長條圖": "multiclass_bar.png",
+    "多元圓餅圖": "multiclass_pie.png",
+}
+
+
+def _get_folder() -> str:
+    if "cisco_visual_folder" not in st.session_state:
+        monitor = get_log_monitor()
+        st.session_state["cisco_visual_folder"] = monitor.settings.get("clean_csv_dir", "")
+    return st.session_state["cisco_visual_folder"]
+
+
+def app() -> None:
+    """顯示自動產生的圖表，提供路徑同步按鈕。"""
+    st.title("📊 圖表產生與檢視")
+    st.markdown("可預覽自動分析後輸出的 PNG 圖表，方便資安人員快速確認趨勢。")
+
+    folder = st.text_input("圖表資料夾", value=_get_folder())
+    st.session_state["cisco_visual_folder"] = folder
+
+    if st.button("同步自動清洗輸出路徑"):
+        monitor = get_log_monitor()
+        st.session_state["cisco_visual_folder"] = monitor.settings.get("clean_csv_dir", "")
+        st.experimental_rerun()
+
+    col1, col2, col3, col4 = st.columns(4)
+    buttons = list(CHART_FILES.keys())
+    cols = [col1, col2, col3, col4]
+    for col, label in zip(cols, buttons):
+        if col.button(label):
+            st.session_state["cisco_visual_selected"] = label
+
+    selected = st.session_state.get("cisco_visual_selected", buttons[0])
+    filename = CHART_FILES[selected]
+    st.markdown(f"#### 目前檢視：{selected}")
+
+    path = os.path.join(st.session_state["cisco_visual_folder"], filename)
+    if folder and os.path.exists(path):
+        st.image(path, caption=f"{selected} ({path})", use_column_width=True)
+    else:
+        st.warning(f"找不到圖表檔案：{path}")

--- a/unified_ui/app.py
+++ b/unified_ui/app.py
@@ -1,0 +1,48 @@
+"""跨品牌統一介面。"""
+from __future__ import annotations
+
+import streamlit as st
+from streamlit.errors import StreamlitAPIException
+
+from .cisco_module import pages as cisco_pages
+from .fortinet_module import pages as fortinet_pages
+
+try:
+    st.set_page_config(page_title="D-FLARE Unified Dashboard", page_icon="🛡️", layout="wide")
+except StreamlitAPIException:
+    pass
+
+BRAND_RENDERERS = {
+    "Fortinet": fortinet_pages.render,
+    "Cisco": cisco_pages.render,
+}
+BRAND_DESCRIPTIONS = {
+    "Fortinet": "Fortinet 版本提供完整的訓練、ETL、推論與通知流程。",
+    "Cisco": "Cisco 版本專注於 ASA log 擷取、模型推論與跨平台通知。",
+}
+
+
+def _select_brand() -> str:
+    if "unified_brand" not in st.session_state:
+        st.session_state["unified_brand"] = "Fortinet"
+    current = st.session_state["unified_brand"]
+    options = list(BRAND_RENDERERS.keys())
+
+    col1, col2 = st.columns([1, 3])
+    with col1:
+        brand = st.selectbox("選擇品牌", options, index=options.index(current))
+    with col2:
+        st.title("D-FLARE 跨品牌控制台")
+        st.caption(BRAND_DESCRIPTIONS.get(brand, ""))
+    st.session_state["unified_brand"] = brand
+    st.divider()
+    return brand
+
+
+def main() -> None:
+    brand = _select_brand()
+    BRAND_RENDERERS[brand]()
+
+
+if __name__ == "__main__":
+    main()

--- a/unified_ui/cisco_module/pages.py
+++ b/unified_ui/cisco_module/pages.py
@@ -1,0 +1,8 @@
+"""Cisco 介面在統一平台中的轉接層。"""
+from __future__ import annotations
+
+from cisco_ui import app as cisco_app
+
+
+def render() -> None:
+    cisco_app.render()

--- a/unified_ui/fortinet_module/pages.py
+++ b/unified_ui/fortinet_module/pages.py
@@ -1,0 +1,112 @@
+"""Fortinet 介面在統一平台的渲染邏輯。"""
+from __future__ import annotations
+
+import streamlit as st
+
+try:
+    from streamlit_option_menu import option_menu
+except ModuleNotFoundError:  # pragma: no cover
+    option_menu = None
+
+from Forti_ui_app_bundle.ui_pages import (
+    folder_monitor_ui,
+    gpu_etl_ui,
+    inference_ui,
+    notifier_app,
+    training_ui,
+    visualization_ui,
+)
+
+PAGES = {
+    "Training Pipeline": training_ui.app,
+    "GPU ETL Pipeline": gpu_etl_ui.app,
+    "Model Inference": inference_ui.app,
+    "Folder Monitor": folder_monitor_ui.app,
+    "Visualization": visualization_ui.app,
+    "Notifications": notifier_app.app,
+}
+PAGE_EMOJIS = {
+    "Training Pipeline": "🛠️",
+    "GPU ETL Pipeline": "🚀",
+    "Model Inference": "🔍",
+    "Folder Monitor": "📁",
+    "Visualization": "📊",
+    "Notifications": "🔔",
+}
+PAGE_ICONS = {
+    "Training Pipeline": "cpu",
+    "GPU ETL Pipeline": "gpu",
+    "Model Inference": "search",
+    "Folder Monitor": "folder",
+    "Visualization": "bar-chart",
+    "Notifications": "bell",
+}
+PAGE_DESCRIPTIONS = {
+    "Training Pipeline": "設定訓練流程與參數。",
+    "GPU ETL Pipeline": "啟動 GPU 加速的 ETL 任務。",
+    "Model Inference": "使用已訓練模型進行推論。",
+    "Folder Monitor": "監控資料夾並自動清洗檔案。",
+    "Visualization": "瀏覽數據可視化結果。",
+    "Notifications": "管理通知與 Gemini 建議。",
+}
+
+
+def render() -> None:
+    if "fortinet_menu_collapse" not in st.session_state:
+        st.session_state["fortinet_menu_collapse"] = False
+    sidebar_width = "72px" if st.session_state["fortinet_menu_collapse"] else "260px"
+
+    st.markdown(
+        f"""
+        <style>
+        div[data-testid="stSidebar"] {{
+            width: {sidebar_width};
+            background-color: #1f2937;
+            transition: width 0.3s ease;
+        }}
+        div[data-testid="stSidebar"] .nav-link {{ color: #e5e7eb; }}
+        div[data-testid="stSidebar"] .nav-link-selected {{ background-color: #2563eb; color: white; }}
+        .menu-collapsed .nav-link span {{ display: none; }}
+        .menu-collapsed .nav-link {{ justify-content: center; }}
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
+    page_keys = list(PAGES.keys())
+    page_labels = [f"{PAGE_EMOJIS[name]} {name}" for name in page_keys]
+
+    with st.sidebar:
+        st.title("Fortinet D-FLARE")
+        st.caption("訓練、推論、視覺化與通知的一站式平台。")
+        if option_menu:
+            if st.button("☰", key="fortinet_menu_toggle"):
+                st.session_state["fortinet_menu_collapse"] = not st.session_state["fortinet_menu_collapse"]
+            menu_class = "menu-collapsed" if st.session_state["fortinet_menu_collapse"] else "menu-expanded"
+            st.markdown(f"<div class='{menu_class}'>", unsafe_allow_html=True)
+            label = option_menu(
+                None,
+                page_labels,
+                icons=[PAGE_ICONS[name] for name in page_keys],
+                menu_icon="cast",
+                default_index=0,
+                styles={
+                    "container": {"padding": "0", "background-color": "#1f2937"},
+                    "icon": {"color": "white", "font-size": "16px"},
+                    "nav-link": {
+                        "color": "#d1d5db",
+                        "font-size": "16px",
+                        "text-align": "left",
+                        "margin": "0px",
+                        "--hover-color": "#4b5563",
+                    },
+                    "nav-link-selected": {"background-color": "#111827"},
+                },
+            )
+            st.markdown("</div>", unsafe_allow_html=True)
+        else:
+            label = st.radio("功能選單", page_labels)
+        selection = page_keys[page_labels.index(label)]
+        st.markdown(PAGE_DESCRIPTIONS.get(selection, ""))
+
+    PAGES[selection]()


### PR DESCRIPTION
## Summary
- rebuild the Cisco interface as a modular Streamlit app with dedicated pages for log monitoring, inference, notifications, visualization, and data cleanup while preserving original functionality
- add shared utilities plus threaded monitoring/cleaning controllers and extensive Chinese comments for maintainability
- create a unified Streamlit dashboard that lets users switch between the Fortinet and Cisco experiences from a single entry point

## Testing
- python -m compileall cisco_ui unified_ui

------
https://chatgpt.com/codex/tasks/task_e_68c882409af08320bd2b3d2ef510a0c4

## Sourcery 总结

将 Cisco UI 重构为具有专用页面和基于线程的控制器的独立 Streamlit 组件，并创建一个统一的仪表板，用于在 Cisco 和 Fortinet 界面之间切换

新功能：
- 引入模块化的 Streamlit 页面，用于 Cisco 日志监控、模型推理、通知、可视化和数据清洗
- 添加一个统一的 Streamlit 仪表板，用于从一个入口点切换 Cisco 和 Fortinet 体验

改进：
- 提取共享工具，用于配置加载、JSON 持久化和带时间戳的日志记录
- 实现基于线程的控制器，用于持续的文件夹监控和自动化数据清洗
- 在所有新模块中添加中文文档注释，以提高可维护性

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the Cisco UI into standalone Streamlit components with dedicated pages and thread-based controllers, and create a unified dashboard to toggle between Cisco and Fortinet interfaces

New Features:
- Introduce modular Streamlit pages for Cisco log monitoring, model inference, notifications, visualization, and data cleaning
- Add a unified Streamlit dashboard to switch between Cisco and Fortinet experiences from one entry point

Enhancements:
- Extract shared utilities for configuration loading, JSON persistence, and timestamped logging
- Implement threaded controllers for continuous folder monitoring and automated data cleaning
- Add Chinese documentation comments throughout the new modules for improved maintainability

</details>