### PR TITLE
Fix Cisco UI module imports for unified dashboard

### DIFF
--- a/Cisco_ui/ui_pages/data_cleaning.py
+++ b/Cisco_ui/ui_pages/data_cleaning.py
@@ -9,8 +9,12 @@ from typing import List
 
 import streamlit as st
 
-from ui_pages.log_monitor import get_log_monitor
-from utils_labels import append_log
+from .log_monitor import get_log_monitor
+
+try:  # When imported via "Cisco_ui" package context
+    from ..utils_labels import append_log
+except (ImportError, ValueError):  # Fallback for legacy top-level execution
+    from utils_labels import append_log  # type: ignore[no-redef]
 
 DEFAULT_EXTENSIONS = [".csv", ".png", ".log"]
 

--- a/Cisco_ui/ui_pages/log_monitor.py
+++ b/Cisco_ui/ui_pages/log_monitor.py
@@ -16,11 +16,16 @@ from typing import Dict, List, Optional, Set, Tuple
 import pandas as pd
 import streamlit as st
 
-from training_pipeline.config import PipelineConfig
-from training_pipeline.trainer import execute_pipeline
-from notifier import notification_pipeline
-
-from utils_labels import append_log, load_json, save_json
+try:  # Prefer package-relative imports when available
+    from ..training_pipeline.config import PipelineConfig
+    from ..training_pipeline.trainer import execute_pipeline
+    from ..notifier import notification_pipeline
+    from ..utils_labels import append_log, load_json, save_json
+except (ImportError, ValueError):  # Support running within the package directory directly
+    from training_pipeline.config import PipelineConfig  # type: ignore[no-redef]
+    from training_pipeline.trainer import execute_pipeline  # type: ignore[no-redef]
+    from notifier import notification_pipeline  # type: ignore[no-redef]
+    from utils_labels import append_log, load_json, save_json  # type: ignore[no-redef]
 
 # 設定檔路徑與預設值定義
 LOG_SETTINGS_FILE = "logfetcher_settings.json"

--- a/Cisco_ui/ui_pages/model_inference.py
+++ b/Cisco_ui/ui_pages/model_inference.py
@@ -8,12 +8,18 @@ from typing import Optional
 import pandas as pd
 import streamlit as st
 
-from training_pipeline.config import PipelineConfig
-from training_pipeline.trainer import execute_pipeline
-from notifier import notification_pipeline
+from .log_monitor import get_log_monitor
 
-from ui_pages.log_monitor import get_log_monitor
-from utils_labels import load_json
+try:  # Package import when used via ``Cisco_ui``
+    from ..training_pipeline.config import PipelineConfig
+    from ..training_pipeline.trainer import execute_pipeline
+    from ..notifier import notification_pipeline
+    from ..utils_labels import load_json
+except (ImportError, ValueError):  # Legacy support for running inside package folder
+    from training_pipeline.config import PipelineConfig  # type: ignore[no-redef]
+    from training_pipeline.trainer import execute_pipeline  # type: ignore[no-redef]
+    from notifier import notification_pipeline  # type: ignore[no-redef]
+    from utils_labels import load_json  # type: ignore[no-redef]
 
 NOTIFIER_SETTINGS_FILE = "notifier_settings.txt"
 

--- a/Cisco_ui/ui_pages/notifications.py
+++ b/Cisco_ui/ui_pages/notifications.py
@@ -6,9 +6,12 @@ from typing import Dict, List
 
 import streamlit as st
 
-from notifier import send_discord
-
-from utils_labels import append_log, load_json, save_json
+try:  # Prefer package-relative imports when available
+    from ..notifier import send_discord
+    from ..utils_labels import append_log, load_json, save_json
+except (ImportError, ValueError):  # Fallback for running inside package folder directly
+    from notifier import send_discord  # type: ignore[no-redef]
+    from utils_labels import append_log, load_json, save_json  # type: ignore[no-redef]
 
 SETTINGS_FILE = "notifier_settings.txt"
 USER_FILE = "line_users.txt"

--- a/Cisco_ui/ui_pages/visualization.py
+++ b/Cisco_ui/ui_pages/visualization.py
@@ -6,7 +6,7 @@ from typing import Dict
 
 import streamlit as st
 
-from ui_pages.log_monitor import get_log_monitor
+from .log_monitor import get_log_monitor
 
 CHART_FILES: Dict[str, str] = {
     "二元長條圖": "binary_bar.png",


### PR DESCRIPTION
## Summary
- update Cisco UI Streamlit pages to prefer package-relative imports while retaining backwards compatibility
- ensure data cleaning, log monitoring, inference, notifications, and visualization screens can load shared helpers in either execution context

## Testing
- python -m compileall Cisco_ui/ui_pages

------
https://chatgpt.com/codex/tasks/task_e_68c8a49d1a788320894f404839b6cd5f

## Sourcery 总结

增强功能：
- 统一 UI 页面使用包相对导入，并回退到顶级导入以实现向后兼容性

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Standardize UI pages to use package-relative imports with fallback to top-level imports for backwards compatibility

</details>