### PR TITLE
Fix Fortinet ETL pipeline imports

### DIFF
--- a/Forti_ui_app_bundle/etl_pipeliner.py
+++ b/Forti_ui_app_bundle/etl_pipeliner.py
@@ -26,11 +26,19 @@ from colorama import Fore, Style, init as colorama_init
 # 初始化色彩
 colorama_init(autoreset=True)
 
-# 匯入個既有模組
-from etl_pipeline import log_cleaning as LC   # 提供 clean_logs() 互動流程
-from etl_pipeline import log_mapping as LM    # 提供映射與排序的工具方法
-from etl_pipeline import feature_engineering as FE  # 提供五大類特徵工程方法
-from etl_pipeline.utils import check_and_flush
+# 匯入個既有模組（支援套件內呼叫與單檔執行）
+try:
+    from etl_pipeline import log_cleaning as LC  # 提供 clean_logs() 互動流程
+    from etl_pipeline import log_mapping as LM  # 提供映射與排序的工具方法
+    from etl_pipeline import feature_engineering as FE  # 提供五大類特徵工程方法
+    from etl_pipeline.utils import check_and_flush
+except ModuleNotFoundError as exc:
+    if exc.name != "etl_pipeline":
+        raise
+    from Forti_ui_app_bundle.etl_pipeline import log_cleaning as LC
+    from Forti_ui_app_bundle.etl_pipeline import log_mapping as LM
+    from Forti_ui_app_bundle.etl_pipeline import feature_engineering as FE
+    from Forti_ui_app_bundle.etl_pipeline.utils import check_and_flush
 
 # 全域靜默模式（非互動呼叫時可避免多餘提示）
 LC.QUIET = False


### PR DESCRIPTION
## Summary
- add a fallback import path for the Fortinet ETL pipeliner so it works both when executed from within the package and when run standalone

## Testing
- ❌ `python - <<'PY'
import importlib
import Forti_ui_app_bundle.etl_pipeliner as ep
print('Imported package mode')
# simulate direct import fallback by altering sys.modules? not necessary.
PY
` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68c8a7ca54d48320beaa2017abe4acac