### PR TITLE
Fix training pipeline imports for unified dashboard

### DIFF
--- a/Forti_ui_app_bundle/ui_pages/training_ui.py
+++ b/Forti_ui_app_bundle/ui_pages/training_ui.py
@@ -11,7 +11,12 @@ _ensure_module("numpy", "numpy_stub")
 
 _ensure_module("pandas", "pandas_stub")
 
-from training_pipeline.pipeline_main import TrainingPipeline
+try:
+    from training_pipeline.pipeline_main import TrainingPipeline
+except ModuleNotFoundError as exc:  # pragma: no cover - local package fallback
+    if exc.name != "training_pipeline":
+        raise
+    from ..training_pipeline import TrainingPipeline
 
 def app() -> None:
     st.title("Training Pipeline")


### PR DESCRIPTION
## Summary
- add a defensive import fallback in the Fortinet training UI so it can load the local training_pipeline package when running from the unified dashboard
- update training_pipeline.pipeline_main to fall back to package-relative imports for project modules and utilities, including a helper for the DMW ensemble class

## Testing
- python -m compileall Forti_ui_app_bundle/training_pipeline/pipeline_main.py Forti_ui_app_bundle/ui_pages/training_ui.py

------
https://chatgpt.com/codex/tasks/task_e_68c8aa58214083209e342df2625b889c

## Sourcery 总结

在训练管道和 UI 模块中添加防御性导入回退，以确保当从统一仪表板运行时，本地包导入能正确加载

Bug 修复：
- 在 `pipeline_main.py` 中为 `utils_labels`、`training_pipeline` 模块、`config` 和 `combo_optimizer` 添加包相对回退导入，以避免在捆绑上下文中出现导入错误
- 在 `training_ui.py` 中为 `TrainingPipeline` 添加回退导入，以便当从统一仪表板运行时加载本地包

增强功能：
- 引入 `_load_dmw_class` 辅助函数，以封装带有包相对回退的 `DynamicSoftVoter` 导入

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add defensive import fallbacks in training pipeline and UI modules to ensure local package imports load correctly when running from the unified dashboard

Bug Fixes:
- Add package-relative fallback imports in pipeline_main.py for utils_labels, training_pipeline modules, config, and combo_optimizer to avoid import errors in bundled context
- Add fallback import for TrainingPipeline in training_ui.py to load the local package when running from the unified dashboard

Enhancements:
- Introduce _load_dmw_class helper to encapsulate DynamicSoftVoter import with package-relative fallback

</details>