### PR TITLE
Refresh unified Streamlit UI styling

### DIFF
--- a/Forti_ui_app_bundle/ui_pages/__init__.py
+++ b/Forti_ui_app_bundle/ui_pages/__init__.py
@@ -37,7 +37,7 @@ __all__ = [
 
 
 def apply_dark_theme() -> None:  # [ADDED]
-    """Inject typography colors optimized for dark surfaces."""
+    """Inject consistent typography and element styling for darker surfaces."""
 
     if st.session_state.get("_df_dark_theme_applied"):  # [ADDED]
         return  # [ADDED]
@@ -47,14 +47,13 @@ def apply_dark_theme() -> None:  # [ADDED]
         """
         <style>
         :root {
-            --df-title-color: #f9fafb;
-            --df-subtitle-color: #e5e7eb;
-            --df-body-color: #d1d5db;
-            --df-muted-color: #9ca3af;
-            --df-button-bg: #1f2937;
-            --df-button-border: #4b5563;
-            --df-button-hover: #374151;
-            --df-warning-color: #fb923c;
+            --df-title-color: var(--text-primary, #f9fafb);
+            --df-body-color: var(--text-secondary, #d1d5db);
+            --df-muted-color: var(--text-secondary, #9ca3af);
+            --df-button-gradient-start: var(--primary, #FF6B2C);
+            --df-button-gradient-end: var(--primary-hover, #FF834D);
+            --df-button-shadow: var(--hover-glow, 0 26px 48px -30px rgba(255, 107, 44, 0.4));
+            --df-warning-color: var(--warning, #FFC107);
             --df-error-color: #f87171;
         }
         div[data-testid="stAppViewContainer"] .main .block-container {
@@ -79,17 +78,22 @@ def apply_dark_theme() -> None:  # [ADDED]
         div[data-testid="stAppViewContainer"] .main .block-container .stMarkdown small {
             color: var(--df-muted-color);
         }
-        div[data-testid="stAppViewContainer"] .main .block-container .stButton > button {
-            color: var(--df-title-color);
-            background-color: var(--df-button-bg);
-            border: 1px solid var(--df-button-border);
+        div[data-testid="stAppViewContainer"] .main .block-container .stButton > button,
+        div[data-testid="stAppViewContainer"] .main .block-container .stDownloadButton > button,
+        div[data-testid="stAppViewContainer"] .main .block-container .stFormSubmitButton > button {
+            background: linear-gradient(135deg, var(--df-button-gradient-start), var(--df-button-gradient-end));
+            color: #ffffff;
+            border: none;
+            border-radius: 14px;
+            box-shadow: var(--df-button-shadow);
         }
-        div[data-testid="stAppViewContainer"] .main .block-container .stButton > button:hover {
-            background-color: var(--df-button-hover);
-            border-color: var(--df-title-color);
+        div[data-testid="stAppViewContainer"] .main .block-container .stButton > button:hover,
+        div[data-testid="stAppViewContainer"] .main .block-container .stDownloadButton > button:hover,
+        div[data-testid="stAppViewContainer"] .main .block-container .stFormSubmitButton > button:hover {
+            transform: translateY(-1px) scale(1.02);
         }
         div[data-testid="stAppViewContainer"] .main .block-container .stAlert {
-            border-radius: 12px;
+            border-radius: 14px;
         }
         div[data-testid="stAppViewContainer"] .main .block-container .stAlert[data-baseweb="alert"][kind="warning"] div[data-testid="stMarkdownContainer"] p {
             color: var(--df-warning-color) !important;
@@ -97,15 +101,16 @@ def apply_dark_theme() -> None:  # [ADDED]
         div[data-testid="stAppViewContainer"] .main .block-container .stAlert[data-baseweb="alert"][kind="error"] div[data-testid="stMarkdownContainer"] p {
             color: var(--df-error-color) !important;
         }
-        div[data-testid="stAppViewContainer"] .main .block-container .stAlert[data-baseweb="alert"][kind="info"] div[data-testid="stMarkdownContainer"] p {
-            color: var(--df-subtitle-color) !important;
-        }
-        div[data-testid="stAppViewContainer"] .main .block-container .stAlert[data-baseweb="alert"][kind="success"] div[data-testid="stMarkdownContainer"] p {
-            color: var(--df-title-color) !important;
-        }
         div[data-testid="stAppViewContainer"] .main .block-container pre,
         div[data-testid="stAppViewContainer"] .main .block-container code {
             color: var(--df-title-color);
+        }
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-baseweb="input"] input,
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-baseweb="input"] textarea {
+            background: var(--input-background, #0f172a) !important;
+            color: var(--df-title-color) !important;
+            border: 1px solid var(--input-border, #334155) !important;
+            border-radius: 12px;
         }
         </style>
         """,

--- a/unified_ui/app.py
+++ b/unified_ui/app.py
@@ -1,4 +1,4 @@
-"""跨品牌統一介面。"""
+"""跨品牌統一介面的現代化版本。"""
 from __future__ import annotations
 
 import html
@@ -8,9 +8,6 @@ import streamlit as st
 from streamlit.errors import StreamlitAPIException
 
 if __package__ in (None, ""):
-    # Support running "streamlit run unified_ui/app.py" by adding the current
-    # directory to ``sys.path`` so the sibling modules can be imported without
-    # package context.
     import sys
     from pathlib import Path
 
@@ -41,61 +38,86 @@ BRAND_TITLES = {
     "Fortinet": "Fortinet D-FLARE 控制台",
     "Cisco": "Cisco D-FLARE 控制台",
 }
-# [ADDED] 明暗主題配色設定
 THEME_PRESETS = {
     "dark": {
         "color_mode": "dark",
-        "background": "#0f172a",
-        "surface": "#1e293b",
-        "surface_muted": "#15213b",
-        "surface_border": "rgba(148, 163, 184, 0.22)",
-        "surface_shadow": "0 32px 55px -32px rgba(8, 15, 27, 0.9)",
-        "sidebar_background": "#1e293b",
-        "sidebar_text": "#f1f5f9",
+        "background": "#0b101f",
+        "surface": "#11182a",
+        "surface_muted": "#15203a",
+        "surface_border": "rgba(148, 163, 184, 0.18)",
+        "surface_shadow": "0 42px 88px -48px rgba(8, 12, 24, 0.92)",
+        "sidebar_background": "#0f172a",
+        "sidebar_text": "#f8fafc",
         "sidebar_muted": "#94a3b8",
         "sidebar_button_hover": "rgba(148, 163, 184, 0.16)",
-        "text_primary": "#f1f5f9",
+        "sidebar_icon": "#f8fafc",
+        "sidebar_icon_hover": "#ffb48a",
+        "text_primary": "#e2e8f0",
         "text_secondary": "#94a3b8",
-        "card_background": "#1f2937",
-        "card_border": "rgba(148, 163, 184, 0.2)",
-        "card_shadow": "0 26px 42px -32px rgba(8, 15, 27, 0.9)",
-        "button_background": "#2563eb",
-        "button_hover": "#1d4ed8",
-        "warning_yellow": "#facc15",
-        "warning_red": "#ef4444",
-        "expander_header": "#243147",
-        "expander_background": "#16213b",
-        "code_background": "#111827",
-        "input_background": "#111827",
+        "card_background": "#18233a",
+        "card_border": "rgba(148, 163, 184, 0.22)",
+        "card_shadow": "0 32px 62px -38px rgba(3, 7, 18, 0.85)",
+        "primary": "#E85C1F",
+        "primary_hover": "#FF6B2C",
+        "primary_shadow": "rgba(232, 92, 31, 0.45)",
+        "secondary_start": "#1ABC9C",
+        "secondary_end": "#9B59B6",
+        "secondary_hover": "#23cfb0",
+        "warning": "#FFC107",
+        "warning_emphasis": "#FF9800",
+        "alert_icon_bg": "rgba(255, 193, 7, 0.18)",
+        "alert_icon_color": "#ffffff",
+        "expander_header": "#1b2740",
+        "expander_background": "#111a2c",
+        "code_background": "#0b1220",
+        "input_background": "#0f172a",
         "input_border": "#334155",
-        "muted_border": "#27344a",
+        "muted_border": "rgba(148, 163, 184, 0.3)",
+        "upload_background": "#13203a",
+        "upload_border": "rgba(255, 255, 255, 0.18)",
+        "upload_text": "#f8fafc",
+        "hover_glow": "0 28px 60px -32px rgba(232, 92, 31, 0.55)",
+        "sidebar_badge_background": "rgba(232, 92, 31, 0.18)",
     },
     "light": {
         "color_mode": "light",
-        "background": "#f8fafc",
-        "surface": "#f1f5f9",
-        "surface_muted": "#e2e8f0",
-        "surface_border": "#d2d9e4",
-        "surface_shadow": "0 24px 48px -32px rgba(15, 23, 42, 0.14)",
-        "sidebar_background": "#e2e8f0",
+        "background": "#f5f7fb",
+        "surface": "#ffffff",
+        "surface_muted": "#eef2ff",
+        "surface_border": "#d8e0f0",
+        "surface_shadow": "0 32px 64px -46px rgba(15, 23, 42, 0.2)",
+        "sidebar_background": "#f1f5f9",
         "sidebar_text": "#0f172a",
-        "sidebar_muted": "#475569",
-        "sidebar_button_hover": "rgba(148, 163, 184, 0.32)",
-        "text_primary": "#0f172a",
+        "sidebar_muted": "#64748b",
+        "sidebar_button_hover": "rgba(15, 23, 42, 0.08)",
+        "sidebar_icon": "#0f172a",
+        "sidebar_icon_hover": "#FF6B2C",
+        "text_primary": "#1f2937",
         "text_secondary": "#475569",
         "card_background": "#ffffff",
-        "card_border": "#d0d7e3",
-        "card_shadow": "0 22px 36px -26px rgba(15, 23, 42, 0.18)",
-        "button_background": "#2563eb",
-        "button_hover": "#1e40af",
-        "warning_yellow": "#ca8a04",
-        "warning_red": "#b91c1c",
-        "expander_header": "#d9e2ef",
-        "expander_background": "#edf2fb",
-        "code_background": "#e2e8f0",
+        "card_border": "#d9e2f1",
+        "card_shadow": "0 24px 54px -34px rgba(15, 23, 42, 0.22)",
+        "primary": "#FF6B2C",
+        "primary_hover": "#FF834D",
+        "primary_shadow": "rgba(255, 107, 44, 0.32)",
+        "secondary_start": "#1ABC9C",
+        "secondary_end": "#9B59B6",
+        "secondary_hover": "#22a68c",
+        "warning": "#FFC107",
+        "warning_emphasis": "#ff9800",
+        "alert_icon_bg": "rgba(255, 193, 7, 0.18)",
+        "alert_icon_color": "#7a5200",
+        "expander_header": "#e4ecfb",
+        "expander_background": "#f5f8ff",
+        "code_background": "#eef2ff",
         "input_background": "#ffffff",
-        "input_border": "#cbd5f5",
-        "muted_border": "#cbd5f5",
+        "input_border": "#d0d6eb",
+        "muted_border": "#d8e0f0",
+        "upload_background": "#ffffff",
+        "upload_border": "#ffd4bc",
+        "upload_text": "#0f172a",
+        "hover_glow": "0 28px 60px -32px rgba(255, 107, 44, 0.35)",
+        "sidebar_badge_background": "rgba(255, 107, 44, 0.16)",
     },
 }
 DEFAULT_THEME = {
@@ -134,21 +156,28 @@ BRAND_HIGHLIGHTS: dict[str, list[Highlight]] = {
         ("🌐", "跨平台告警", "彈性整合多種通訊渠道，將分析結果分送至各平台。"),
     ],
 }
+FEATURE_VARIANTS = {
+    "全流程管控": "primary",
+    "GPU ETL 加速": "secondary",
+    "智慧告警": "alert",
+    "ASA 日誌擷取": "primary",
+    "模型推論指引": "secondary",
+    "跨平台告警": "alert",
+}
 SIDEBAR_TITLE = "D-FLARE Unified"
-# Sidebar tagline removed for a cleaner layout.  # [REMOVED]
 
 _T = TypeVar("_T")
 
 
-def _ensure_session_defaults() -> None:  # [MODIFIED]
-    st.session_state.setdefault("unified_brand", "Fortinet")  # [MODIFIED]
-    st.session_state.setdefault("fortinet_menu_collapse", False)  # [MODIFIED]
-    st.session_state.setdefault("unified_theme", "dark")  # [ADDED]
+def _ensure_session_defaults() -> None:
+    st.session_state.setdefault("unified_brand", "Fortinet")
+    st.session_state.setdefault("unified_theme", "dark")
+    st.session_state.setdefault("fortinet_menu_collapse", False)
+    st.session_state.setdefault("cisco_menu_collapse", False)
 
 
-def _apply_theme_styles(collapsed: bool, palette: dict[str, str]) -> None:  # [MODIFIED]
-    sidebar_width = "88px" if collapsed else "296px"  # [MODIFIED]
-    st.markdown(  # [MODIFIED]
+def _apply_theme_styles(palette: dict[str, str]) -> None:
+    st.markdown(
         f"""
         <style>
         :root {{
@@ -160,27 +189,43 @@ def _apply_theme_styles(collapsed: bool, palette: dict[str, str]) -> None:  # [M
             --app-surface-shadow: {palette['surface_shadow']};
             --text-primary: {palette['text_primary']};
             --text-secondary: {palette['text_secondary']};
-            --accent: {palette['button_background']};
-            --accent-hover: {palette['button_hover']};
             --sidebar-bg: {palette['sidebar_background']};
             --sidebar-text: {palette['sidebar_text']};
             --sidebar-muted: {palette['sidebar_muted']};
             --sidebar-button-hover: {palette['sidebar_button_hover']};
+            --sidebar-icon: {palette['sidebar_icon']};
+            --sidebar-icon-hover: {palette['sidebar_icon_hover']};
             --card-background: {palette['card_background']};
             --card-border: {palette['card_border']};
             --card-shadow: {palette['card_shadow']};
-            --warning-yellow: {palette['warning_yellow']};
-            --warning-red: {palette['warning_red']};
+            --primary: {palette['primary']};
+            --primary-hover: {palette['primary_hover']};
+            --primary-shadow: {palette['primary_shadow']};
+            --secondary-start: {palette['secondary_start']};
+            --secondary-end: {palette['secondary_end']};
+            --secondary-hover: {palette['secondary_hover']};
+            --warning: {palette['warning']};
+            --warning-emphasis: {palette['warning_emphasis']};
+            --alert-icon-bg: {palette['alert_icon_bg']};
+            --alert-icon-color: {palette['alert_icon_color']};
             --expander-header: {palette['expander_header']};
             --expander-background: {palette['expander_background']};
             --code-background: {palette['code_background']};
             --input-background: {palette['input_background']};
             --input-border: {palette['input_border']};
             --muted-border: {palette['muted_border']};
+            --upload-background: {palette['upload_background']};
+            --upload-border: {palette['upload_border']};
+            --upload-text: {palette['upload_text']};
+            --hover-glow: {palette['hover_glow']};
+            --sidebar-badge-bg: {palette['sidebar_badge_background']};
+            --accent: {palette['primary']};
+            --accent-hover: {palette['primary_hover']};
         }}
 
         * {{
-            transition: background-color 0.25s ease, color 0.25s ease, border-color 0.25s ease;
+            transition: background-color 0.25s ease, color 0.25s ease, border-color 0.25s ease,
+                box-shadow 0.25s ease, transform 0.25s ease;
         }}
 
         html, body, div[data-testid="stAppViewContainer"] {{
@@ -189,42 +234,35 @@ def _apply_theme_styles(collapsed: bool, palette: dict[str, str]) -> None:  # [M
 
         body {{
             color: var(--text-primary);
-            font-family: "Noto Sans TC", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+            font-family: "Noto Sans TC", "Inter", "Segoe UI", system-ui, -apple-system,
+                BlinkMacSystemFont, sans-serif;
         }}
 
-        h1, h2, h3, h4, h5, h6 {{
-            color: var(--text-primary);
+        header, #MainMenu {{
+            display: none;
         }}
 
-        p, label, span, li {{
-            color: var(--text-primary);
+        footer {{
+            visibility: hidden;
         }}
 
-        small, .stCaption, .stMarkdown small, div[data-testid="stMarkdown"] em {{
-            color: var(--text-secondary) !important;
-        }}
-
-        a {{
-            color: var(--accent);
-        }}
-
-        a:hover {{
-            color: var(--accent-hover);
-        }}
-
-        code, pre {{
-            background: var(--code-background);
-            color: var(--text-primary);
-            border-radius: 10px;
+        div[data-testid="stDecoration"] {{
+            display: none !important;
         }}
 
         div[data-testid="stSidebar"] {{
-            width: {sidebar_width};
-            min-width: {sidebar_width};
+            width: 296px;
+            min-width: 296px;
             background: var(--sidebar-bg);
             border-right: 1px solid var(--app-surface-border);
-            padding: 1.25rem 0.9rem 2rem;
-            transition: width 0.3s ease;
+            padding: 1.6rem 1.25rem 2.8rem;
+        }}
+
+        @media (max-width: 992px) {{
+            div[data-testid="stSidebar"] {{
+                width: 100%;
+                min-width: 0;
+            }}
         }}
 
         div[data-testid="stSidebar"] section[data-testid="stSidebarContent"] {{
@@ -232,60 +270,240 @@ def _apply_theme_styles(collapsed: bool, palette: dict[str, str]) -> None:  # [M
         }}
 
         div[data-testid="stSidebar"] h1,
+        div[data-testid="stSidebar"] h2,
+        div[data-testid="stSidebar"] h3,
+        div[data-testid="stSidebar"] h4,
+        div[data-testid="stSidebar"] h5,
+        div[data-testid="stSidebar"] h6,
         div[data-testid="stSidebar"] label,
         div[data-testid="stSidebar"] span,
         div[data-testid="stSidebar"] p {{
             color: var(--sidebar-text) !important;
         }}
 
-        div[data-testid="stSidebar"] .stMarkdown small,
-        div[data-testid="stSidebar"] .stCaption {{
+        div[data-testid="stSidebar"] .sidebar-heading {{
+            margin-bottom: 1.4rem;
+        }}
+
+        div[data-testid="stSidebar"] .sidebar-eyebrow {{
+            display: inline-flex;
+            align-items: center;
+            font-size: 0.78rem;
+            letter-spacing: 0.18em;
+            text-transform: uppercase;
+            color: var(--sidebar-muted);
+            font-weight: 600;
+        }}
+
+        div[data-testid="stSidebar"] .sidebar-title {{
+            font-size: 1.45rem;
+            font-weight: 700;
+            margin: 0.3rem 0 0.4rem;
+            color: var(--sidebar-text);
+        }}
+
+        div[data-testid="stSidebar"] .sidebar-tagline {{
+            font-size: 0.9rem;
+            line-height: 1.5;
+            color: var(--sidebar-muted);
+            margin: 0;
+        }}
+
+        div[data-testid="stSidebar"] .sidebar-note {{
+            margin: 1.25rem 0 0;
+            font-size: 0.82rem;
+            color: var(--sidebar-muted);
+        }}
+
+        div[data-testid="stSidebar"] div[data-testid="stToggle"] {{
+            border: 1px solid var(--muted-border);
+            border-radius: 14px;
+            padding: 0.75rem 0.85rem;
+            background: var(--app-surface);
+            box-shadow: 0 24px 38px -32px var(--primary-shadow);
+            margin: 1.1rem 0 1.6rem;
+        }}
+
+        div[data-testid="stSidebar"] div[data-testid="stToggle"] label {{
+            color: var(--sidebar-text);
+            font-weight: 600;
+            width: 100%;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 0.75rem;
+        }}
+
+        div[data-testid="stSidebar"] div[data-testid="stToggle"] [role="switch"] {{
+            background: var(--sidebar-button-hover);
+            border-radius: 999px;
+        }}
+
+        div[data-testid="stSidebar"] .stSelectbox > label {{
+            font-size: 0.9rem;
+            font-weight: 600;
             color: var(--sidebar-muted) !important;
+            margin-bottom: 0.45rem;
+        }}
+
+        div[data-testid="stSidebar"] .stSelectbox div[data-baseweb="select"] > div {{
+            background: transparent;
+            border: 1px solid var(--muted-border);
+            border-radius: 12px;
+            color: var(--sidebar-text);
+            padding: 0.25rem 0.5rem;
+        }}
+
+        div[data-testid="stSidebar"] .stSelectbox div[data-baseweb="select"] > div:hover {{
+            border-color: var(--primary);
+            box-shadow: var(--hover-glow);
+        }}
+
+        div[data-testid="stSidebar"] .stSelectbox div[data-baseweb="select"] span {{
+            color: var(--sidebar-text);
+        }}
+
+        div[data-testid="stSidebar"] .sidebar-nav {{
+            margin-top: 1.35rem;
+            display: flex;
+            flex-direction: column;
+            gap: 0.35rem;
+        }}
+
+        div[data-testid="stSidebar"] .sidebar-nav .nav-link {{
+            color: var(--sidebar-text) !important;
+            border-radius: 12px !important;
+            padding: 0.65rem 0.85rem !important;
+            font-weight: 600;
+            font-size: 0.98rem;
+            background: transparent !important;
+            border: 1px solid transparent !important;
+            display: flex !important;
+            align-items: center;
+            gap: 0.65rem;
+        }}
+
+        div[data-testid="stSidebar"] .sidebar-nav .nav-link:hover {{
+            background: var(--sidebar-button-hover) !important;
+            color: var(--sidebar-text) !important;
+            transform: translateX(4px);
+            box-shadow: var(--hover-glow);
+        }}
+
+        div[data-testid="stSidebar"] .sidebar-nav .nav-link i {{
+            color: var(--sidebar-icon) !important;
+            font-size: 1rem !important;
+            transition: color 0.2s ease;
+        }}
+
+        div[data-testid="stSidebar"] .sidebar-nav .nav-link:hover i {{
+            color: var(--sidebar-icon-hover) !important;
+        }}
+
+        div[data-testid="stSidebar"] .sidebar-nav .nav-link-selected {{
+            background: linear-gradient(135deg, var(--primary), var(--primary-hover)) !important;
+            color: #ffffff !important;
+            box-shadow: var(--hover-glow);
+            transform: translateX(4px);
+        }}
+
+        div[data-testid="stSidebar"] .sidebar-nav .nav-link-selected i {{
+            color: #ffffff !important;
+        }}
+
+        div[data-testid="stSidebar"] .sidebar-menu-description {{
+            color: var(--sidebar-muted) !important;
+            font-size: 0.85rem;
+            margin: 0.4rem 0 1.25rem;
+            line-height: 1.45;
         }}
 
         div[data-testid="stSidebar"] hr {{
-            margin: 1.5rem 0 0;
             border-color: var(--muted-border);
+            margin: 1.6rem 0 1.2rem;
         }}
 
-        div[data-testid="stSidebar"] .stButton > button {{
-            width: 100%;
-            background: transparent;
+        div[data-testid="stSidebar"] .sidebar-badge {{
+            display: inline-flex;
+            align-items: center;
+            gap: 0.45rem;
+            padding: 0.45rem 0.75rem;
+            border-radius: 999px;
+            background: var(--sidebar-badge-bg);
             color: var(--sidebar-text);
-            border: 1px solid var(--muted-border);
-            border-radius: 12px;
             font-weight: 600;
-            padding: 0.55rem 0.75rem;
+            font-size: 0.82rem;
         }}
 
-        div[data-testid="stSidebar"] .stButton > button:hover {{
-            background: var(--sidebar-button-hover);
-            border-color: transparent;
-            color: var(--sidebar-text);
-        }}
-
-        div[data-testid="stSidebar"] .stButton > button:focus-visible {{
-            outline: 2px solid var(--accent);
-            outline-offset: 2px;
-        }}
-
-        .stButton > button {{
-            background: var(--accent);
-            color: #f8fafc;
-            border-radius: 12px;
+        .stButton > button,
+        .stDownloadButton > button,
+        .stFormSubmitButton > button {{
+            background: linear-gradient(135deg, var(--primary), var(--primary-hover));
+            color: #ffffff;
             border: none;
+            border-radius: 14px;
+            padding: 0.75rem 1.45rem;
             font-weight: 600;
-            padding: 0.6rem 1.2rem;
-            box-shadow: 0 12px 22px -16px rgba(37, 99, 235, 0.65);
+            font-size: 0.98rem;
+            box-shadow: var(--hover-glow);
         }}
 
-        .stButton > button:hover {{
-            background: var(--accent-hover);
+        .stButton > button:hover,
+        .stDownloadButton > button:hover,
+        .stFormSubmitButton > button:hover {{
+            transform: translateY(-1px) scale(1.02);
+            box-shadow: 0 26px 48px -24px var(--primary-shadow);
         }}
 
-        .stButton > button:focus-visible {{
-            outline: 2px solid var(--accent-hover);
-            outline-offset: 2px;
+        .stButton > button:focus-visible,
+        .stDownloadButton > button:focus-visible,
+        .stFormSubmitButton > button:focus-visible {{
+            outline: 2px solid rgba(255, 255, 255, 0.35);
+            outline-offset: 3px;
+        }}
+
+        div[data-testid="stFileUploader"] {{
+            margin-bottom: 1.5rem;
+        }}
+
+        div[data-testid="stFileUploader"] > label {{
+            font-weight: 600;
+            font-size: 0.95rem;
+            color: var(--text-secondary);
+            margin-bottom: 0.6rem;
+        }}
+
+        div[data-testid="stFileUploader"] section[data-testid="stFileUploaderDropzone"] {{
+            border: 1px dashed var(--upload-border);
+            background: var(--upload-background);
+            color: var(--upload-text);
+            border-radius: 18px;
+            padding: 1.1rem;
+        }}
+
+        div[data-testid="stFileUploader"] section[data-testid="stFileUploaderDropzone"]:hover {{
+            border-color: var(--primary);
+            transform: translateY(-2px) scale(1.01);
+            box-shadow: var(--hover-glow);
+        }}
+
+        div[data-testid="stFileUploader"] section[data-testid="stFileUploaderDropzone"] span {{
+            color: var(--upload-text);
+        }}
+
+        div[data-testid="stFileUploader"] button {{
+            background: linear-gradient(135deg, var(--secondary-start), var(--secondary-end));
+            color: #ffffff;
+            border: none;
+            border-radius: 12px;
+            padding: 0.5rem 1.1rem;
+            font-weight: 600;
+            box-shadow: var(--hover-glow);
+        }}
+
+        div[data-testid="stFileUploader"] button:hover {{
+            transform: translateY(-1px);
+            box-shadow: 0 24px 44px -26px rgba(27, 172, 156, 0.5);
         }}
 
         div[data-testid="stAppViewContainer"] .main {{
@@ -294,51 +512,87 @@ def _apply_theme_styles(collapsed: bool, palette: dict[str, str]) -> None:  # [M
 
         div[data-testid="stAppViewContainer"] .main .block-container {{
             background: var(--app-surface);
-            border-radius: 24px;
+            border-radius: 28px;
             border: 1px solid var(--app-surface-border);
             box-shadow: var(--app-surface-shadow);
-            padding: 2.4rem 3rem 3.1rem;
+            padding: 2.6rem 3rem 3rem;
+            display: flex;
+            flex-direction: column;
+            gap: 1.8rem;
         }}
 
         @media (max-width: 992px) {{
             div[data-testid="stAppViewContainer"] .main .block-container {{
-                padding: 1.8rem 1.5rem 2.2rem;
-                border-radius: 20px;
+                padding: 2rem 1.6rem 2.4rem;
+                border-radius: 22px;
             }}
         }}
 
-        div[data-testid="stMarkdown"] p {{
+        div[data-testid="stAppViewContainer"] .main .block-container h1 {{
+            font-size: 2.35rem;
+            font-weight: 700;
+            margin: 0;
             color: var(--text-primary);
         }}
 
-        hr {{
-            border-color: var(--muted-border);
+        div[data-testid="stAppViewContainer"] .main .block-container h2 {{
+            font-size: 1.6rem;
+            font-weight: 700;
+            margin-bottom: 0.4rem;
+            color: var(--text-primary);
+        }}
+
+        div[data-testid="stAppViewContainer"] .main .block-container h3 {{
+            font-size: 1.35rem;
+            font-weight: 600;
+            margin-bottom: 0.35rem;
+            color: var(--text-primary);
+        }}
+
+        div[data-testid="stAppViewContainer"] .main .block-container p,
+        div[data-testid="stAppViewContainer"] .main .block-container span,
+        div[data-testid="stAppViewContainer"] .main .block-container label,
+        div[data-testid="stAppViewContainer"] .main .block-container li {{
+            color: var(--text-primary);
+        }}
+
+        div[data-testid="stAppViewContainer"] .main .block-container small,
+        div[data-testid="stAppViewContainer"] .main .block-container .stCaption,
+        div[data-testid="stAppViewContainer"] .main .block-container .stMarkdown small {{
+            color: var(--text-secondary) !important;
         }}
 
         .stTabs [role="tablist"] {{
-            gap: 0.5rem;
-            border-bottom: 1px solid var(--muted-border);
+            gap: 0.75rem;
+            border-bottom: none;
             padding-bottom: 0.25rem;
         }}
 
         .stTabs [role="tab"] {{
-            background: transparent;
+            border-radius: 999px;
+            padding: 0.45rem 1.1rem;
+            font-weight: 600;
             color: var(--text-secondary);
-            border: none;
-            border-bottom: 2px solid transparent;
-            padding: 0.4rem 0.6rem;
-            font-weight: 500;
+            background: var(--app-surface-muted);
+            border: 1px solid var(--muted-border);
+        }}
+
+        .stTabs [role="tab"]:hover {{
+            color: var(--text-primary);
+            transform: translateY(-1px);
+            box-shadow: var(--hover-glow);
         }}
 
         .stTabs [role="tab"][aria-selected="true"] {{
-            color: var(--text-primary);
-            border-color: var(--accent);
-            font-weight: 600;
+            background: linear-gradient(135deg, var(--primary), var(--primary-hover));
+            color: #ffffff;
+            box-shadow: var(--hover-glow);
+            border-color: transparent;
         }}
 
         div[data-testid="stExpander"] > details {{
             background: var(--expander-background);
-            border-radius: 16px;
+            border-radius: 18px;
             border: 1px solid var(--muted-border);
             overflow: hidden;
         }}
@@ -346,7 +600,7 @@ def _apply_theme_styles(collapsed: bool, palette: dict[str, str]) -> None:  # [M
         div[data-testid="stExpander"] > details > summary {{
             background: var(--expander-header);
             color: var(--text-primary);
-            padding: 0.85rem 1rem;
+            padding: 0.95rem 1.1rem;
             font-weight: 600;
         }}
 
@@ -355,7 +609,7 @@ def _apply_theme_styles(collapsed: bool, palette: dict[str, str]) -> None:  # [M
         }}
 
         div[data-testid="stExpander"] > details div[data-testid="stExpanderContent"] {{
-            padding: 0.85rem 1rem 1rem;
+            padding: 0.95rem 1.1rem 1.1rem;
             color: var(--text-primary);
         }}
 
@@ -363,13 +617,13 @@ def _apply_theme_styles(collapsed: bool, palette: dict[str, str]) -> None:  # [M
             display: flex;
             align-items: center;
             justify-content: space-between;
-            gap: 1.5rem;
-            padding: 1.8rem 2.1rem;
-            border-radius: 22px;
+            gap: 1.8rem;
+            padding: 1.9rem 2.2rem;
+            border-radius: 24px;
             position: relative;
             overflow: hidden;
             background: linear-gradient(135deg, var(--accent-start), var(--accent-end));
-            box-shadow: 0 28px 52px -28px var(--accent-shadow);
+            box-shadow: 0 32px 58px -32px var(--accent-shadow);
             color: #f8fafc;
         }}
 
@@ -377,8 +631,8 @@ def _apply_theme_styles(collapsed: bool, palette: dict[str, str]) -> None:  # [M
             content: "";
             position: absolute;
             inset: 0;
-            background: radial-gradient(circle at top right, rgba(255, 255, 255, 0.32), transparent 60%);
-            opacity: 0.7;
+            background: radial-gradient(circle at top right, rgba(255, 255, 255, 0.28), transparent 60%);
+            opacity: 0.75;
             pointer-events: none;
         }}
 
@@ -396,10 +650,10 @@ def _apply_theme_styles(collapsed: bool, palette: dict[str, str]) -> None:  # [M
         }}
 
         .brand-hero h1 {{
-            margin: 0.35rem 0 0.75rem;
-            font-size: 2rem;
+            margin: 0.45rem 0 0.85rem;
+            font-size: 2.4rem;
             font-weight: 700;
-            letter-spacing: 0.02em;
+            letter-spacing: 0.01em;
         }}
 
         .brand-hero p {{
@@ -412,7 +666,7 @@ def _apply_theme_styles(collapsed: bool, palette: dict[str, str]) -> None:  # [M
         .brand-hero__badge {{
             position: relative;
             z-index: 1;
-            padding: 0.55rem 1.4rem;
+            padding: 0.6rem 1.5rem;
             border-radius: 999px;
             border: 1px solid rgba(255, 255, 255, 0.48);
             background: rgba(15, 23, 42, 0.28);
@@ -425,123 +679,114 @@ def _apply_theme_styles(collapsed: bool, palette: dict[str, str]) -> None:  # [M
         }}
 
         .feature-card {{
-            margin-top: 1.25rem;
-            padding: 1.2rem 1.3rem;
-            border-radius: 20px;
+            padding: 1.4rem 1.5rem;
+            border-radius: 22px;
             border: 1px solid var(--card-border);
             background: var(--card-background);
             box-shadow: var(--card-shadow);
-            transition: transform 0.2s ease, box-shadow 0.2s ease;
+            transition: transform 0.25s ease, box-shadow 0.25s ease;
         }}
 
         .feature-card:hover {{
-            transform: translateY(-4px);
-            box-shadow: 0 32px 56px -30px rgba(37, 99, 235, 0.35);
+            transform: translateY(-4px) scale(1.02);
+            box-shadow: var(--hover-glow);
         }}
 
         .feature-card__icon {{
-            font-size: 1.75rem;
-            margin-bottom: 0.65rem;
+            width: 52px;
+            height: 52px;
+            border-radius: 50%;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 1.6rem;
+            margin-bottom: 1rem;
+            background: linear-gradient(135deg, var(--secondary-start), var(--secondary-end));
+            color: #ffffff;
+            box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
+        }}
+
+        .feature-card[data-variant="primary"] .feature-card__icon {{
+            background: linear-gradient(135deg, var(--primary), var(--primary-hover));
+        }}
+
+        .feature-card[data-variant="secondary"] .feature-card__icon {{
+            background: linear-gradient(135deg, var(--secondary-start), var(--secondary-end));
+        }}
+
+        .feature-card[data-variant="alert"] .feature-card__icon {{
+            background: var(--alert-icon-bg);
+            color: var(--alert-icon-color);
+            box-shadow: inset 0 0 0 1px rgba(255, 193, 7, 0.32);
         }}
 
         .feature-card__title {{
-            margin: 0 0 0.35rem;
-            font-size: 1.05rem;
-            font-weight: 600;
+            font-size: 1.12rem;
+            font-weight: 700;
             color: var(--text-primary);
+            margin-bottom: 0.5rem;
         }}
 
         .feature-card__desc {{
+            color: var(--text-secondary);
             margin: 0;
-            color: var(--text-secondary);
-            line-height: 1.6;
             font-size: 0.95rem;
+            line-height: 1.6;
         }}
 
-        .stSelectbox label,
-        .stMultiSelect label,
-        .stRadio > label,
-        .stCheckbox > label {{
-            font-weight: 600;
-        }}
-
-        .stSelectbox div[data-baseweb="select"],
-        .stMultiSelect div[data-baseweb="select"] {{
-            border-radius: 12px;
-        }}
-
-        .stSelectbox div[data-baseweb="select"] > div,
-        .stMultiSelect div[data-baseweb="select"] > div {{
-            background: var(--input-background);
-            border: 1px solid var(--input-border);
-            color: var(--text-primary);
-        }}
-
-        .stSelectbox div[data-baseweb="select"] svg,
-        .stMultiSelect div[data-baseweb="select"] svg {{
-            color: var(--text-secondary);
-        }}
-
-        div[data-baseweb="popover"] {{
-            background: var(--card-background);
-            border-radius: 12px;
-            border: 1px solid var(--card-border);
-            box-shadow: var(--card-shadow);
-        }}
-
-        div[data-baseweb="popover"] ul[role="listbox"] li {{
-            color: var(--text-primary);
-            background: var(--card-background);
-        }}
-
-        div[data-baseweb="popover"] ul[role="listbox"] li:hover {{
-            background: var(--app-surface-muted);
-        }}
-
-        .stTextInput input,
-        .stNumberInput input,
-        .stTextArea textarea {{
-            background: var(--input-background);
-            border: 1px solid var(--input-border);
-            color: var(--text-primary);
-            border-radius: 12px;
-        }}
-
-        .stTextInput input:focus,
-        .stNumberInput input:focus,
-        .stTextArea textarea:focus {{
-            border-color: var(--accent);
-            box-shadow: 0 0 0 1px var(--accent);
-        }}
-
-        div[data-testid="stSidebar"] .stSelectbox div[data-baseweb="select"] > div {{
-            background: var(--input-background);
-        }}
-
-        div[data-testid="stSidebar"] .stSelectbox div[data-baseweb="select"] > div:hover {{
-            border-color: transparent;
+        hr {{
+            border-color: var(--muted-border);
         }}
 
         .stAlert {{
             border-radius: 16px;
             border: 1px solid var(--muted-border);
-            background: var(--app-surface);
+            background: var(--app-surface-muted);
+            box-shadow: var(--hover-glow);
         }}
 
         .stAlert div[role="alert"] p {{
             color: var(--text-primary);
         }}
 
-        .stAlert[data-baseweb="notification"] svg {{
-            color: var(--accent);
+        .stAlert[data-baseweb="alert"][kind="warning"] {{
+            border-left: 4px solid var(--warning);
         }}
 
-        .stAlert[data-baseweb="notification"] [data-icon="warning"] {{
-            color: var(--warning-yellow);
+        .stAlert[data-baseweb="alert"][kind="error"] {{
+            border-left: 4px solid var(--warning-emphasis);
         }}
 
-        .stAlert[data-baseweb="notification"] [data-icon="error"] {{
-            color: var(--warning-red);
+        code, pre {{
+            background: var(--code-background);
+            color: var(--text-primary);
+            border-radius: 10px;
+            padding: 0.2rem 0.45rem;
+        }}
+
+        div[data-baseweb="input"] input,
+        div[data-baseweb="input"] textarea,
+        div[data-baseweb="select"] > div {{
+            background: var(--input-background) !important;
+            color: var(--text-primary) !important;
+            border-radius: 12px;
+        }}
+
+        div[data-baseweb="input"] input,
+        div[data-baseweb="input"] textarea {{
+            border: 1px solid var(--input-border) !important;
+        }}
+
+        div[data-baseweb="input"] input:hover,
+        div[data-baseweb="input"] textarea:hover,
+        div[data-baseweb="select"] > div:hover {{
+            border-color: var(--primary) !important;
+            box-shadow: var(--hover-glow);
+        }}
+
+        div[data-testid="stMetricValue"] {{
+            color: var(--primary);
+            font-weight: 700;
         }}
         </style>
         """,
@@ -549,39 +794,38 @@ def _apply_theme_styles(collapsed: bool, palette: dict[str, str]) -> None:  # [M
     )
 
 
-def _render_sidebar(current_theme: str) -> str:  # [MODIFIED]
-    options = list(BRAND_RENDERERS.keys())  # [MODIFIED]
-    collapsed = st.session_state.get("fortinet_menu_collapse", False)  # [MODIFIED]
-
-    with st.sidebar:  # [MODIFIED]
-        if collapsed:  # [ADDED]
-            if st.button("☰", key="unified_sidebar_toggle"):  # [MODIFIED]
-                st.session_state["fortinet_menu_collapse"] = False  # [MODIFIED]
-            if st.button("🌙 / ☀️", key="unified_theme_toggle"):  # [ADDED]
-                st.session_state["unified_theme"] = "light" if current_theme == "dark" else "dark"  # [ADDED]
-        else:  # [ADDED]
-            toggle_col, theme_col = st.columns(2)  # [MODIFIED]
-            with toggle_col:  # [ADDED]
-                if st.button("☰", key="unified_sidebar_toggle"):  # [MODIFIED]
-                    st.session_state["fortinet_menu_collapse"] = True  # [MODIFIED]
-            with theme_col:  # [ADDED]
-                if st.button("🌙 / ☀️", key="unified_theme_toggle"):  # [ADDED]
-                    st.session_state["unified_theme"] = "light" if current_theme == "dark" else "dark"  # [ADDED]
-
-        if not collapsed:  # [MODIFIED]
-            st.title(SIDEBAR_TITLE)  # [MODIFIED]
-
-        label_visibility = "collapsed" if collapsed else "visible"  # [MODIFIED]
-        brand = st.selectbox(  # [MODIFIED]
-            "選擇品牌",  # [MODIFIED]
-            options,  # [MODIFIED]
-            key="unified_brand",  # [MODIFIED]
-            label_visibility=label_visibility,  # [MODIFIED]
+def _render_sidebar(current_theme: str) -> str:
+    options = list(BRAND_RENDERERS.keys())
+    with st.sidebar:
+        st.markdown(
+            f"""
+            <div class="sidebar-heading">
+                <span class="sidebar-eyebrow">Unified Console</span>
+                <div class="sidebar-title">{html.escape(SIDEBAR_TITLE)}</div>
+                <p class="sidebar-tagline">跨品牌威脅分析流程，以一致的體驗呈現。</p>
+            </div>
+            """,
+            unsafe_allow_html=True,
         )
 
-        st.divider()  # [MODIFIED]
+        is_dark = st.toggle("深色介面", value=current_theme == "dark", key="unified_theme_toggle")
+        st.session_state["unified_theme"] = "dark" if is_dark else "light"
 
-    return brand  # [MODIFIED]
+        brand = st.selectbox("選擇品牌", options, key="unified_brand")
+
+        st.markdown(
+            f"<span class='sidebar-badge'>現在瀏覽：{html.escape(brand)}</span>",
+            unsafe_allow_html=True,
+        )
+
+        st.markdown(
+            "<p class='sidebar-note'>所有模組共用相同的視覺語言與互動效果，確保跨品牌的一致體驗。</p>",
+            unsafe_allow_html=True,
+        )
+
+        st.divider()
+
+    return brand
 
 
 def _chunked(seq: Sequence[_T], size: int) -> Iterator[Sequence[_T]]:
@@ -597,9 +841,10 @@ def _render_brand_highlights(brand: str) -> bool:
     for row in _chunked(highlights, 3):
         columns = st.columns(len(row))
         for column, (icon, title, desc) in zip(columns, row):
+            variant = FEATURE_VARIANTS.get(title, "secondary")
             column.markdown(
                 f"""
-                <div class="feature-card">
+                <div class="feature-card" data-variant="{html.escape(variant)}">
                     <div class="feature-card__icon">{html.escape(icon)}</div>
                     <h4 class="feature-card__title">{html.escape(title)}</h4>
                     <p class="feature-card__desc">{html.escape(desc)}</p>
@@ -631,13 +876,18 @@ def _render_main_header(brand: str) -> None:
 
 
 def main() -> None:
-    _ensure_session_defaults()  # [MODIFIED]
-    current_theme = st.session_state.get("unified_theme", "dark")  # [ADDED]
-    brand = _render_sidebar(current_theme)  # [MODIFIED]
-    collapsed = st.session_state.get("fortinet_menu_collapse", False)  # [ADDED]
-    theme_key = st.session_state.get("unified_theme", current_theme)  # [ADDED]
-    palette = THEME_PRESETS.get(theme_key, THEME_PRESETS["dark"])  # [ADDED]
-    _apply_theme_styles(collapsed, palette)  # [MODIFIED]
+    _ensure_session_defaults()
+    initial_theme = st.session_state.get("unified_theme", "dark")
+    palette = THEME_PRESETS.get(initial_theme, THEME_PRESETS["dark"])
+    _apply_theme_styles(palette)
+
+    brand = _render_sidebar(initial_theme)
+
+    updated_theme = st.session_state.get("unified_theme", initial_theme)
+    if updated_theme != initial_theme:
+        palette = THEME_PRESETS.get(updated_theme, THEME_PRESETS["dark"])
+        _apply_theme_styles(palette)
+
     _render_main_header(brand)
     _render_brand_highlights(brand)
     st.divider()

--- a/unified_ui/cisco_module/pages.py
+++ b/unified_ui/cisco_module/pages.py
@@ -1,6 +1,8 @@
 """Cisco 介面在統一平台中的轉接層。"""
 from __future__ import annotations
 
+import html
+
 import streamlit as st
 
 try:
@@ -11,7 +13,6 @@ except ModuleNotFoundError:  # pragma: no cover - 選用套件
 from Cisco_ui import ui_app as cisco_app
 
 PAGES = cisco_app.PAGES
-PAGE_EMOJIS = cisco_app.PAGE_EMOJIS
 PAGE_ICONS = cisco_app.PAGE_ICONS
 PAGE_DESCRIPTIONS = cisco_app.PAGE_DESCRIPTIONS
 
@@ -24,77 +25,47 @@ def _configure_page() -> None:
 
 def render() -> None:
     _configure_page()
-    if "fortinet_menu_collapse" not in st.session_state:
-        st.session_state["fortinet_menu_collapse"] = False
-    collapsed = st.session_state["fortinet_menu_collapse"]
-
-    st.markdown(
-        """
-        <style>
-        div[data-testid="stSidebar"] .cisco-menu .nav-link {
-            color: #dbeafe;
-        }
-        div[data-testid="stSidebar"] .cisco-menu .nav-link:hover {
-            background-color: #1e3a8a;
-        }
-        div[data-testid="stSidebar"] .cisco-menu .nav-link-selected {
-            background-color: #1d4ed8;
-            color: #ffffff;
-        }
-        .menu-collapsed .cisco-menu .nav-link span {
-            display: none;
-        }
-        .menu-collapsed .cisco-menu .nav-link {
-            justify-content: center;
-        }
-        div[data-testid="stSidebar"] .cisco-menu-description {
-            color: #9ca3af;
-            font-size: 0.85rem;
-            margin-top: 0.75rem;
-        }
-        </style>
-        """,
-        unsafe_allow_html=True,
-    )
+    st.session_state.setdefault("fortinet_menu_collapse", False)
 
     page_keys = list(PAGES.keys())
-    page_labels = [f"{PAGE_EMOJIS[name]} {name}" for name in page_keys]
+    page_labels = page_keys
 
     with st.sidebar:
-        menu_class = "menu-collapsed" if collapsed else "menu-expanded"
         if option_menu:
-            st.markdown(f"<div class='cisco-menu {menu_class}'>", unsafe_allow_html=True)
-            label = option_menu(
+            default_page = st.session_state.get("cisco_active_page", page_keys[0])
+            default_index = page_keys.index(default_page) if default_page in page_keys else 0
+            st.markdown("<div class='sidebar-nav sidebar-nav--cisco'>", unsafe_allow_html=True)
+            selection = option_menu(
                 None,
                 page_labels,
                 icons=[PAGE_ICONS[name] for name in page_keys],
                 menu_icon="list",
-                default_index=0,
+                default_index=default_index,
+                key="cisco_sidebar_menu",
                 styles={
                     "container": {"padding": "0", "background-color": "transparent"},
-                    "icon": {"color": "white", "font-size": "16px"},
+                    "icon": {"color": "var(--sidebar-icon)", "font-size": "18px"},
                     "nav-link": {
-                        "color": "#bfdbfe",
+                        "color": "var(--sidebar-text)",
                         "font-size": "15px",
                         "text-align": "left",
                         "margin": "0px",
-                        "--hover-color": "#1e3a8a",
+                        "--hover-color": "var(--sidebar-button-hover)",
                     },
-                    "nav-link-selected": {"background-color": "#2563eb"},
+                    "nav-link-selected": {"background-color": "transparent"},
                 },
             )
             st.markdown("</div>", unsafe_allow_html=True)
         else:
-            label_visibility = "collapsed" if collapsed else "visible"
-            label = st.radio("功能選單", page_labels, label_visibility=label_visibility)
+            selection = st.radio("功能選單", page_labels, key="cisco_sidebar_menu")
 
-        selection = page_keys[page_labels.index(label)]
-        if not collapsed:
-            description = PAGE_DESCRIPTIONS.get(selection, "")
-            if description:
-                st.markdown(
-                    f"<p class='cisco-menu-description'>{description}</p>",
-                    unsafe_allow_html=True,
-                )
+        st.session_state["cisco_active_page"] = selection
+
+        description = PAGE_DESCRIPTIONS.get(selection, "")
+        if description:
+            st.markdown(
+                f"<p class='sidebar-menu-description'>{html.escape(description)}</p>",
+                unsafe_allow_html=True,
+            )
 
     PAGES[selection]()

--- a/unified_ui/fortinet_module/pages.py
+++ b/unified_ui/fortinet_module/pages.py
@@ -1,6 +1,8 @@
 """Fortinet 介面在統一平台的渲染邏輯。"""
 from __future__ import annotations
 
+import html
+
 import streamlit as st
 
 try:
@@ -25,14 +27,6 @@ PAGES = {
     "Visualization": visualization_ui.app,
     "Notifications": notifier_app.app,
 }
-PAGE_EMOJIS = {
-    "Training Pipeline": "🛠️",
-    "GPU ETL Pipeline": "🚀",
-    "Model Inference": "🔍",
-    "Folder Monitor": "📁",
-    "Visualization": "📊",
-    "Notifications": "🔔",
-}
 PAGE_ICONS = {
     "Training Pipeline": "cpu",
     "GPU ETL Pipeline": "gpu",
@@ -52,77 +46,48 @@ PAGE_DESCRIPTIONS = {
 
 
 def render() -> None:
-    if "fortinet_menu_collapse" not in st.session_state:
-        st.session_state["fortinet_menu_collapse"] = False
-    collapsed = st.session_state["fortinet_menu_collapse"]
-
-    st.markdown(
-        """
-        <style>
-        div[data-testid="stSidebar"] .fortinet-menu .nav-link {
-            color: #d1d5db;
-        }
-        div[data-testid="stSidebar"] .fortinet-menu .nav-link:hover {
-            background-color: #374151;
-        }
-        div[data-testid="stSidebar"] .fortinet-menu .nav-link-selected {
-            background-color: #111827;
-            color: #f9fafb;
-        }
-        .menu-collapsed .fortinet-menu .nav-link span {
-            display: none;
-        }
-        .menu-collapsed .fortinet-menu .nav-link {
-            justify-content: center;
-        }
-        div[data-testid="stSidebar"] .fortinet-menu-description {
-            color: #9ca3af;
-            font-size: 0.85rem;
-            margin-top: 0.75rem;
-        }
-        </style>
-        """,
-        unsafe_allow_html=True,
-    )
+    # 維持舊狀態鍵以免其他模組存取時發生 KeyError。
+    st.session_state.setdefault("fortinet_menu_collapse", False)
 
     page_keys = list(PAGES.keys())
-    page_labels = [f"{PAGE_EMOJIS[name]} {name}" for name in page_keys]
+    page_labels = page_keys
 
     with st.sidebar:
-        menu_class = "menu-collapsed" if collapsed else "menu-expanded"
         if option_menu:
-            st.markdown(f"<div class='fortinet-menu {menu_class}'>", unsafe_allow_html=True)
-            label = option_menu(
+            default_page = st.session_state.get("fortinet_active_page", page_keys[0])
+            default_index = page_keys.index(default_page) if default_page in page_keys else 0
+            st.markdown("<div class='sidebar-nav sidebar-nav--fortinet'>", unsafe_allow_html=True)
+            selection = option_menu(
                 None,
                 page_labels,
                 icons=[PAGE_ICONS[name] for name in page_keys],
                 menu_icon="cast",
-                default_index=0,
+                default_index=default_index,
+                key="fortinet_sidebar_menu",
                 styles={
                     "container": {"padding": "0", "background-color": "transparent"},
-                    "icon": {"color": "white", "font-size": "16px"},
+                    "icon": {"color": "var(--sidebar-icon)", "font-size": "18px"},
                     "nav-link": {
-                        "color": "#d1d5db",
-                        "font-size": "16px",
+                        "color": "var(--sidebar-text)",
+                        "font-size": "15px",
                         "text-align": "left",
                         "margin": "0px",
-                        "--hover-color": "#374151",
+                        "--hover-color": "var(--sidebar-button-hover)",
                     },
-                    "nav-link-selected": {"background-color": "#111827"},
+                    "nav-link-selected": {"background-color": "transparent"},
                 },
             )
             st.markdown("</div>", unsafe_allow_html=True)
         else:
-            label_visibility = "collapsed" if collapsed else "visible"
-            label = st.radio("功能選單", page_labels, label_visibility=label_visibility)
+            selection = st.radio("功能選單", page_labels, key="fortinet_sidebar_menu")
 
-        selection = page_keys[page_labels.index(label)]
-        if not collapsed:
-            description = PAGE_DESCRIPTIONS.get(selection, "")
-            if description:
-                st.markdown(
-                    f"<p class='fortinet-menu-description'>{description}</p>",
-                    unsafe_allow_html=True,
-                )
+        st.session_state["fortinet_active_page"] = selection
+
+        description = PAGE_DESCRIPTIONS.get(selection, "")
+        if description:
+            st.markdown(
+                f"<p class='sidebar-menu-description'>{html.escape(description)}</p>",
+                unsafe_allow_html=True,
+            )
 
     PAGES[selection]()


### PR DESCRIPTION
## Summary
- Overhauled the unified dashboard theme with modern light/dark palettes, consistent typography hierarchy, new gradients, and hover feedback across cards, tabs, buttons, and uploaders.
- Simplified the sidebar by removing the collapse toggle, adding a stylized theme switch, and ensuring the Fortinet and Cisco menus rely on single-tone icons with high-contrast descriptions.
- Updated the shared Fortinet page styling helper so standalone modules pick up the refreshed gradients, shadows, and input treatments.

## Testing
- python -m compileall unified_ui Forti_ui_app_bundle

------
https://chatgpt.com/codex/tasks/task_e_68d0c566a6f883209ececeb81a382c71