### PR TITLE
Revamp unified UI theming and Cisco file selectors

### DIFF
--- a/Cisco_ui/ui_pages/model_inference.py
+++ b/Cisco_ui/ui_pages/model_inference.py
@@ -1,6 +1,7 @@
 """Cisco 模型推論頁面模組。"""
 from __future__ import annotations
 
+import html
 import os
 import tempfile
 from typing import Optional
@@ -33,6 +34,32 @@ def _write_temp_file(upload, suffix: str) -> Optional[str]:
         return tmp.name
 
 
+def _render_path_preview(label: str, value: str, *, icon: str = "📁") -> None:
+    """以一致樣式呈現檔案路徑或名稱。"""
+
+    safe_label = html.escape(label)
+    safe_icon = html.escape(icon)
+    if value:
+        safe_value = html.escape(value)
+        extra_class = ""
+    else:
+        safe_value = "尚未選擇"
+        extra_class = " path-preview--empty"
+
+    st.markdown(
+        f"""
+        <div class="path-preview{extra_class}">
+            <span class="path-preview__icon">{safe_icon}</span>
+            <div class="path-preview__content">
+                <span class="path-preview__label">{safe_label}</span>
+                <span class="path-preview__path">{safe_value}</span>
+            </div>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
 def app() -> None:
     """提供手動執行完整 Pipeline 的頁面。"""
     st.title("🔍 Cisco 模型推論與批次分析")
@@ -40,26 +67,91 @@ def app() -> None:
 
     monitor = get_log_monitor()
     default_output = monitor.settings.get("clean_csv_dir", "")
+    saved_log = monitor.last_processed_file
+    saved_binary = st.session_state.get("cisco_binary_model_path", monitor.settings.get("binary_model_path", ""))
+    saved_multi = st.session_state.get("cisco_multi_model_path", monitor.settings.get("model_path", ""))
 
     st.markdown("#### 1. 選擇輸入檔案")
-    upload_log = st.file_uploader("上傳原始 log (CSV/TXT/GZ)", type=["csv", "txt", "gz"])
-    manual_log_path = st.text_input("或輸入既有 log 路徑", value=monitor.last_processed_file)
+    upload_log = st.file_uploader(
+        "上傳原始 log (CSV/TXT/GZ)",
+        type=["csv", "txt", "gz"],
+        key="cisco_inference_log_uploader",
+    )
+    can_use_recent = bool(saved_log)
+    use_recent_log = st.checkbox(
+        "使用最近的監控檔案",
+        value=can_use_recent,
+        disabled=not can_use_recent,
+        key="cisco_use_recent_log_checkbox",
+        help="若先前於「Log 擷取」頁面完成分析，可直接重用最新的檔案。",
+    )
+    if not can_use_recent:
+        use_recent_log = False
+    if upload_log is not None:
+        use_recent_log = False
+        st.session_state["cisco_use_recent_log_checkbox"] = False
+        _render_path_preview("上傳的 log 檔案", upload_log.name, icon="📄")
+    elif use_recent_log and saved_log:
+        _render_path_preview("最近的監控檔案", saved_log, icon="📄")
+    else:
+        _render_path_preview("目前選擇的 log 檔案", "", icon="📄")
+        if not saved_log:
+            st.caption("尚未有監控紀錄，可於「Log 擷取」頁面執行自動分析後再回到此處。")
 
     st.markdown("#### 2. 模型設定")
-    upload_binary = st.file_uploader("上傳二元模型 (.pkl)", type=["pkl"], key="binary_upload")
-    manual_binary_path = st.text_input("或輸入二元模型路徑", value=monitor.settings.get("binary_model_path", ""))
+    upload_binary = st.file_uploader(
+        "上傳二元模型 (.pkl/.joblib)",
+        type=["pkl", "joblib"],
+        key="binary_upload",
+    )
+    if upload_binary is not None:
+        _render_path_preview("上傳的二元模型", upload_binary.name, icon="🧠")
+    else:
+        _render_path_preview("目前儲存的二元模型", saved_binary, icon="🧠")
+        if not saved_binary:
+            st.caption("尚未設定二元模型，可於「Log 擷取」頁面上傳並儲存。")
 
-    upload_multi = st.file_uploader("上傳多元模型 (.pkl)", type=["pkl"], key="multi_upload")
-    manual_multi_path = st.text_input("或輸入多元模型路徑", value=monitor.settings.get("model_path", ""))
+    upload_multi = st.file_uploader(
+        "上傳多元模型 (.pkl/.joblib)",
+        type=["pkl", "joblib"],
+        key="multi_upload",
+    )
+    if upload_multi is not None:
+        _render_path_preview("上傳的多元模型", upload_multi.name, icon="🗂️")
+    else:
+        _render_path_preview("目前儲存的多元模型", saved_multi, icon="🗂️")
+        if not saved_multi:
+            st.caption("尚未設定多元模型，可於「Log 擷取」頁面上傳並儲存。")
 
     st.markdown("#### 3. 輸出設定")
-    output_dir = st.text_input("輸出資料夾", value=default_output)
+    output_dir = st.text_input(
+        "輸出資料夾",
+        value=default_output,
+        placeholder="例如：/data/cisco/output",
+    )
     auto_notify = st.checkbox("自動觸發通知模組", value=True)
 
     if st.button("🚀 執行 Pipeline"):
-        log_path = _write_temp_file(upload_log, suffix=os.path.splitext(upload_log.name)[1]) if upload_log else manual_log_path
-        binary_path = _write_temp_file(upload_binary, suffix=".pkl") if upload_binary else manual_binary_path
-        multi_path = _write_temp_file(upload_multi, suffix=".pkl") if upload_multi else manual_multi_path
+        log_path = None
+        if upload_log is not None:
+            log_suffix = os.path.splitext(upload_log.name)[1] or ".log"
+            log_path = _write_temp_file(upload_log, suffix=log_suffix)
+        elif use_recent_log and saved_log:
+            log_path = saved_log
+
+        binary_path = None
+        if upload_binary is not None:
+            binary_suffix = os.path.splitext(upload_binary.name)[1] or ".pkl"
+            binary_path = _write_temp_file(upload_binary, suffix=binary_suffix)
+        else:
+            binary_path = saved_binary
+
+        multi_path = None
+        if upload_multi is not None:
+            multi_suffix = os.path.splitext(upload_multi.name)[1] or ".pkl"
+            multi_path = _write_temp_file(upload_multi, suffix=multi_suffix)
+        else:
+            multi_path = saved_multi
 
         errors = []
         if not log_path or not os.path.exists(log_path):

--- a/Forti_ui_app_bundle/ui_pages/__init__.py
+++ b/Forti_ui_app_bundle/ui_pages/__init__.py
@@ -47,12 +47,12 @@ def apply_dark_theme() -> None:  # [ADDED]
         """
         <style>
         :root {
-            --df-title-color: var(--text-primary, #f9fafb);
-            --df-body-color: var(--text-secondary, #d1d5db);
-            --df-muted-color: var(--text-secondary, #9ca3af);
-            --df-button-gradient-start: var(--primary, #FF6B2C);
-            --df-button-gradient-end: var(--primary-hover, #FF834D);
-            --df-button-shadow: var(--hover-glow, 0 26px 48px -30px rgba(255, 107, 44, 0.4));
+            --df-title-color: var(--text-primary, #ffffff);
+            --df-body-color: var(--text-secondary, #b0b0b0);
+            --df-muted-color: var(--text-secondary, #9aa8c2);
+            --df-button-gradient-start: var(--primary, #1ABC9C);
+            --df-button-gradient-end: var(--primary-hover, #9B59B6);
+            --df-button-shadow: var(--hover-glow, 0 32px 64px -34px rgba(26, 188, 156, 0.55));
             --df-warning-color: var(--warning, #FFC107);
             --df-error-color: #f87171;
         }
@@ -77,6 +77,8 @@ def apply_dark_theme() -> None:  # [ADDED]
         div[data-testid="stAppViewContainer"] .main .block-container .stCaption,
         div[data-testid="stAppViewContainer"] .main .block-container .stMarkdown small {
             color: var(--df-muted-color);
+            font-size: 0.95rem;
+            line-height: 1.55;
         }
         div[data-testid="stAppViewContainer"] .main .block-container .stButton > button,
         div[data-testid="stAppViewContainer"] .main .block-container .stDownloadButton > button,
@@ -107,10 +109,16 @@ def apply_dark_theme() -> None:  # [ADDED]
         }
         div[data-testid="stAppViewContainer"] .main .block-container div[data-baseweb="input"] input,
         div[data-testid="stAppViewContainer"] .main .block-container div[data-baseweb="input"] textarea {
-            background: var(--input-background, #0f172a) !important;
+            background: var(--input-background, #0a121f) !important;
             color: var(--df-title-color) !important;
-            border: 1px solid var(--input-border, #334155) !important;
+            border: 1px solid var(--input-border, #3b4f6d) !important;
             border-radius: 12px;
+        }
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stTextArea"] textarea {
+            background: var(--code-background, #0b1220) !important;
+            color: var(--df-title-color) !important;
+            border: 1px solid var(--input-border, #3b4f6d) !important;
+            border-radius: 14px !important;
         }
         </style>
         """,

--- a/unified_ui/app.py
+++ b/unified_ui/app.py
@@ -41,43 +41,43 @@ BRAND_TITLES = {
 THEME_PRESETS = {
     "dark": {
         "color_mode": "dark",
-        "background": "#060c1a",
+        "background": "#040914",
         "surface": "#0b1426",
         "surface_muted": "#15213a",
-        "surface_border": "rgba(148, 163, 184, 0.2)",
-        "surface_shadow": "0 42px 88px -48px rgba(6, 12, 24, 0.92)",
-        "sidebar_background": "#070f21",
-        "sidebar_text": "#f8fafc",
-        "sidebar_muted": "#cbd5f5",
-        "sidebar_button_hover": "rgba(99, 102, 241, 0.18)",
-        "sidebar_icon": "#f8fafc",
-        "sidebar_icon_hover": "#7dd3fc",
-        "text_primary": "#f1f5ff",
-        "text_secondary": "#d1dcff",
+        "surface_border": "rgba(120, 144, 180, 0.28)",
+        "surface_shadow": "0 42px 88px -48px rgba(4, 8, 20, 0.9)",
+        "sidebar_background": "#060f1f",
+        "sidebar_text": "#ffffff",
+        "sidebar_muted": "#b0c4ff",
+        "sidebar_button_hover": "rgba(26, 188, 156, 0.18)",
+        "sidebar_icon": "#ffffff",
+        "sidebar_icon_hover": "#8be9dd",
+        "text_primary": "#ffffff",
+        "text_secondary": "#b0b0b0",
         "card_background": "#111d34",
-        "card_border": "rgba(148, 163, 184, 0.26)",
-        "card_shadow": "0 32px 62px -38px rgba(3, 7, 18, 0.88)",
-        "primary": "#20c8be",
-        "primary_hover": "#6366f1",
-        "primary_shadow": "rgba(99, 102, 241, 0.45)",
+        "card_border": "rgba(120, 144, 180, 0.34)",
+        "card_shadow": "0 36px 72px -42px rgba(5, 10, 22, 0.92)",
+        "primary": "#1ABC9C",
+        "primary_hover": "#9B59B6",
+        "primary_shadow": "rgba(154, 89, 182, 0.48)",
         "secondary_start": "#38bdf8",
-        "secondary_end": "#818cf8",
+        "secondary_end": "#6366f1",
         "secondary_hover": "#22d3ee",
         "warning": "#facc15",
         "warning_emphasis": "#f59e0b",
-        "alert_icon_bg": "rgba(250, 204, 21, 0.2)",
+        "alert_icon_bg": "rgba(250, 204, 21, 0.24)",
         "alert_icon_color": "#ffffff",
         "expander_header": "#162441",
         "expander_background": "#101a30",
-        "code_background": "#0b1224",
-        "input_background": "#0f1a30",
-        "input_border": "#445b7f",
-        "muted_border": "rgba(148, 163, 184, 0.32)",
-        "upload_background": "#15233f",
-        "upload_border": "rgba(148, 163, 184, 0.32)",
-        "upload_text": "#f1f5ff",
-        "hover_glow": "0 30px 68px -36px rgba(99, 102, 241, 0.52)",
-        "sidebar_badge_background": "rgba(99, 102, 241, 0.22)",
+        "code_background": "#0b1220",
+        "input_background": "#0a121f",
+        "input_border": "#3b4f6d",
+        "muted_border": "rgba(120, 144, 180, 0.38)",
+        "upload_background": "#101a2d",
+        "upload_border": "rgba(26, 188, 156, 0.35)",
+        "upload_text": "#f8fafc",
+        "hover_glow": "0 32px 64px -34px rgba(26, 188, 156, 0.55)",
+        "sidebar_badge_background": "rgba(26, 188, 156, 0.24)",
     },
     "light": {
         "color_mode": "light",
@@ -91,7 +91,7 @@ THEME_PRESETS = {
         "sidebar_muted": "#64748b",
         "sidebar_button_hover": "rgba(15, 23, 42, 0.08)",
         "sidebar_icon": "#0f172a",
-        "sidebar_icon_hover": "#FF6B2C",
+        "sidebar_icon_hover": "#1f2937",
         "text_primary": "#1f2937",
         "text_secondary": "#475569",
         "card_background": "#ffffff",
@@ -242,7 +242,8 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
         body .stCaption,
         body .caption {{
             color: var(--text-secondary) !important;
-            font-size: 0.9rem;
+            font-size: 0.95rem;
+            line-height: 1.55;
         }}
 
         header, #MainMenu {{
@@ -364,7 +365,7 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
         div[data-testid="stSidebar"] .stSelectbox > label {{
             font-size: 0.9rem;
             font-weight: 600;
-            color: var(--sidebar-muted) !important;
+            color: var(--sidebar-text) !important;
             margin-bottom: 0.45rem;
         }}
 
@@ -481,7 +482,7 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
         .stButton > button:focus-visible,
         .stDownloadButton > button:focus-visible,
         .stFormSubmitButton > button:focus-visible {{
-            outline: 2px solid rgba(255, 255, 255, 0.35);
+            outline: 2px solid rgba(26, 188, 156, 0.45);
             outline-offset: 3px;
         }}
 
@@ -492,7 +493,7 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
         div[data-testid="stFileUploader"] > label {{
             font-weight: 600;
             font-size: 1rem;
-            color: var(--text-secondary);
+            color: var(--text-primary);
             margin-bottom: 0.65rem;
         }}
 
@@ -536,7 +537,7 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
         }}
 
         div[data-testid="stToggle"] label {{
-            color: var(--text-secondary);
+            color: var(--text-primary);
             font-weight: 600;
         }}
 
@@ -732,7 +733,7 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
         }}
 
         .feature-card {{
-            padding: 1.65rem 1.75rem 1.55rem;
+            padding: 2.1rem 1.9rem 1.65rem;
             border-radius: 22px;
             border: 1px solid var(--card-border);
             background: var(--card-background);
@@ -741,7 +742,7 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
             display: flex;
             flex-direction: column;
             gap: 0.75rem;
-            margin-top: 0.75rem;
+            margin-top: 1.25rem;
         }}
 
         .feature-card:hover {{
@@ -778,7 +779,7 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
         }}
 
         .feature-card__title {{
-            font-size: 1.12rem;
+            font-size: 1.18rem;
             font-weight: 700;
             color: var(--text-primary);
             margin-bottom: 0.25rem;
@@ -789,6 +790,65 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
             margin: 0;
             font-size: 0.98rem;
             line-height: 1.65;
+        }}
+
+        .path-preview {{
+            display: flex;
+            align-items: center;
+            gap: 0.85rem;
+            background: var(--app-surface-muted);
+            border: 1px solid var(--muted-border);
+            border-radius: 16px;
+            padding: 0.85rem 1.1rem;
+            margin-bottom: 0.85rem;
+            box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+        }}
+
+        .path-preview__icon {{
+            width: 36px;
+            height: 36px;
+            border-radius: 12px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            background: linear-gradient(135deg, var(--secondary-start), var(--secondary-end));
+            color: #ffffff;
+            font-size: 1.1rem;
+            flex-shrink: 0;
+        }}
+
+        .path-preview__content {{
+            display: flex;
+            flex-direction: column;
+            gap: 0.2rem;
+        }}
+
+        .path-preview__label {{
+            font-weight: 600;
+            color: var(--text-primary);
+            font-size: 0.95rem;
+        }}
+
+        .path-preview__path {{
+            color: var(--text-secondary);
+            font-family: "JetBrains Mono", "Roboto Mono", monospace;
+            font-size: 0.92rem;
+            word-break: break-all;
+            line-height: 1.5;
+        }}
+
+        .path-preview--empty {{
+            border-style: dashed;
+            opacity: 0.85;
+        }}
+
+        .path-preview--empty .path-preview__icon {{
+            background: rgba(148, 163, 184, 0.2);
+            color: var(--text-secondary);
+        }}
+
+        .path-preview--empty .path-preview__path {{
+            color: var(--text-secondary);
         }}
 
         hr {{
@@ -846,12 +906,12 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
         }}
 
         div[data-testid="stTextArea"] label {{
-            color: var(--text-secondary) !important;
+            color: var(--text-primary) !important;
             font-weight: 600;
         }}
 
         div[data-testid="stTextArea"] textarea {{
-            background: var(--input-background) !important;
+            background: var(--code-background) !important;
             color: var(--text-primary) !important;
             border-radius: 14px !important;
             border: 1px solid var(--input-border) !important;

--- a/unified_ui/fortinet_module/pages.py
+++ b/unified_ui/fortinet_module/pages.py
@@ -28,9 +28,9 @@ PAGES = {
     "Notifications": notifier_app.app,
 }
 PAGE_ICONS = {
-    "Training Pipeline": "cpu",
-    "GPU ETL Pipeline": "gpu",
-    "Model Inference": "search",
+    "Training Pipeline": "gear",
+    "GPU ETL Pipeline": "speedometer2",
+    "Model Inference": "cpu",
     "Folder Monitor": "folder",
     "Visualization": "bar-chart",
     "Notifications": "bell",


### PR DESCRIPTION
## Summary
- refresh the unified dark/light palettes so headers render in high-contrast white, sidebar icons stay monochrome, and interactive elements share gradient hover treatments
- add reusable path preview styling plus darker text-area backgrounds to align Fortinet and Cisco pages with the updated theme system
- replace Cisco log and model path text inputs with upload-driven selectors and stored path previews for a consistent browse-based workflow

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d0d72bd85083209064d7f680c997f4