### PR TITLE
Adjust dark mode styling and button layout

### DIFF
--- a/Forti_ui_app_bundle/ui_pages/__init__.py
+++ b/Forti_ui_app_bundle/ui_pages/__init__.py
@@ -50,9 +50,9 @@ def apply_dark_theme() -> None:  # [ADDED]
             --df-title-color: var(--text-h1, var(--text-primary, #ffffff));
             --df-heading2-color: var(--text-h2, var(--text-primary, #ffffff));
             --df-heading3-color: var(--text-h3, var(--text-primary, #ffffff));
-            --df-body-color: var(--text-body, #cccccc);
-            --df-caption-color: var(--text-caption, #aaaaaa);
-            --df-label-color: var(--text-label, #e0e0e0);
+            --df-body-color: var(--text-body, #ffffff);
+            --df-caption-color: var(--text-caption, #ffffff);
+            --df-label-color: var(--text-label, #ffffff);
             --df-font-h1: var(--font-h1, 26px);
             --df-font-h2: var(--font-h2, 22px);
             --df-font-h3: var(--font-h3, 18px);

--- a/Forti_ui_app_bundle/ui_pages/folder_monitor_ui.py
+++ b/Forti_ui_app_bundle/ui_pages/folder_monitor_ui.py
@@ -414,9 +414,11 @@ def app() -> None:
         step=1,
         key="cleanup_hours",
     )
-    if st.button("Clear data now"):
+    action_cols = st.columns(3)
 
-        _cleanup_generated(0, force=True)
+    with action_cols[0]:
+        if st.button("Clear data now", use_container_width=True):
+            _cleanup_generated(0, force=True)
 
     if Observer is None:
         st.error("watchdog is not installed")
@@ -429,25 +431,32 @@ def app() -> None:
 
     start_help = "Please enter a valid folder path before starting." if not folder_valid else None  # [ADDED]
 
-    if st.button("Start monitoring", disabled=start_disabled, help=start_help):  # [MODIFIED]
-        handler = _FileMonitorHandler()
-        observer = Observer()
-        observer.schedule(handler, folder, recursive=False)
-        observer.start()
-        st.session_state.observer = observer
-        st.session_state.handler = handler
-        status_placeholder.text(f"Monitoring started on {folder}")
-        _log_toast(f"Monitoring started on {folder}")
+    with action_cols[1]:
+        if st.button(
+            "Start monitoring",
+            disabled=start_disabled,
+            help=start_help,
+            use_container_width=True,
+        ):  # [MODIFIED]
+            handler = _FileMonitorHandler()
+            observer = Observer()
+            observer.schedule(handler, folder, recursive=False)
+            observer.start()
+            st.session_state.observer = observer
+            st.session_state.handler = handler
+            status_placeholder.text(f"Monitoring started on {folder}")
+            _log_toast(f"Monitoring started on {folder}")
 
-    if st.button("Stop monitoring", disabled=stop_disabled):
-        observer = st.session_state.observer
-        if observer is not None:
-            observer.stop()
-            observer.join()
-            st.session_state.observer = None
-            st.session_state.handler = None
-            status_placeholder.text("Monitoring stopped")
-            _log_toast("Monitoring stopped")
+    with action_cols[2]:
+        if st.button("Stop monitoring", disabled=stop_disabled, use_container_width=True):
+            observer = st.session_state.observer
+            if observer is not None:
+                observer.stop()
+                observer.join()
+                st.session_state.observer = None
+                st.session_state.handler = None
+                status_placeholder.text("Monitoring stopped")
+                _log_toast("Monitoring stopped")
 
     log_placeholder = st.empty()
     progress_bar = st.progress(0)

--- a/unified_ui/app.py
+++ b/unified_ui/app.py
@@ -53,10 +53,10 @@ THEME_PRESETS = {
         "sidebar_icon": "#ffffff",
         "sidebar_icon_hover": "#8be9dd",
         "text_primary": "#ffffff",
-        "text_secondary": "#b0b0b0",
-        "text_body": "#CCCCCC",
-        "text_caption": "#AAAAAA",
-        "text_label": "#E0E0E0",
+        "text_secondary": "#ffffff",
+        "text_body": "#ffffff",
+        "text_caption": "#ffffff",
+        "text_label": "#ffffff",
         "text_h1": "#FFFFFF",
         "text_h2": "#FFFFFF",
         "text_h3": "#FFFFFF",
@@ -811,7 +811,7 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
             margin: 0;
             font-size: 1.05rem;
             line-height: 1.6;
-            color: rgba(241, 245, 249, 0.86);
+            color: rgba(255, 255, 255, 0.95);
         }}
 
         .brand-hero__badge {{
@@ -838,6 +838,8 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
             transition: transform 0.25s ease, box-shadow 0.25s ease;
             display: flex;
             flex-direction: column;
+            align-items: center;
+            text-align: center;
             gap: 1rem;
             margin-top: 1.5rem;
         }}
@@ -856,23 +858,9 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
             justify-content: center;
             font-size: 1.6rem;
             margin-bottom: 1.15rem;
-            background: linear-gradient(135deg, var(--secondary-start), var(--secondary-end));
+            background: linear-gradient(135deg, var(--primary), var(--primary-hover));
             color: #ffffff;
             box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
-        }}
-
-        .feature-card[data-variant="primary"] .feature-card__icon {{
-            background: linear-gradient(135deg, var(--primary), var(--primary-hover));
-        }}
-
-        .feature-card[data-variant="secondary"] .feature-card__icon {{
-            background: linear-gradient(135deg, var(--secondary-start), var(--secondary-end));
-        }}
-
-        .feature-card[data-variant="alert"] .feature-card__icon {{
-            background: var(--alert-icon-bg);
-            color: var(--alert-icon-color);
-            box-shadow: inset 0 0 0 1px rgba(255, 193, 7, 0.32);
         }}
 
         .feature-card__title {{
@@ -880,6 +868,7 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
             font-weight: 700;
             color: var(--text-h3);
             margin-bottom: 0.25rem;
+            text-align: center;
         }}
 
         .feature-card__desc {{
@@ -887,6 +876,7 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
             margin: 0;
             font-size: calc(var(--font-body) - 0.3px);
             line-height: 1.65;
+            text-align: center;
         }}
 
         .path-preview {{


### PR DESCRIPTION
## Summary
- align the Fortinet folder monitoring action buttons horizontally for consistent layout
- switch dark theme typography defaults and fallbacks to white so descriptive text no longer appears gray
- center feature cards and reuse the primary gradient for all icons across both brands

## Testing
- not run (UI changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d0ec782cd48320bd3a75d96e862444

## Sourcery 摘要

将文件夹监控操作按钮按列对齐，将深色主题文本默认值切换为白色，居中功能卡片，并标准化图标渐变

增强功能：
- 将文件夹监控操作按钮排列成三列布局，并采用全宽样式
- 将所有深色模式下的排版默认值和备用方案切换为白色，以提高可读性
- 通过将项目和文本居中对齐，居中功能卡片和描述性文本
- 标准化英雄横幅和功能卡片中的图标背景，以使用主渐变

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align folder monitor action buttons in columns, switch dark theme text defaults to white, center feature cards, and standardize icon gradients

Enhancements:
- Arrange folder-monitoring action buttons in a three-column layout with full-width styling
- Switch all dark-mode typography defaults and fallbacks to white for improved readability
- Center feature cards and descriptive text by aligning items and text centrally
- Standardize icon backgrounds across hero banners and feature cards to use the primary gradient

</details>