### PR TITLE
Adjust dark mode text and center feature cards

### DIFF
--- a/Forti_ui_app_bundle/ui_pages/__init__.py
+++ b/Forti_ui_app_bundle/ui_pages/__init__.py
@@ -62,6 +62,9 @@ def apply_dark_theme() -> None:  # [ADDED]
             --df-button-gradient-start: var(--primary, #1ABC9C);
             --df-button-gradient-end: var(--primary-hover, #9B59B6);
             --df-button-shadow: var(--hover-glow, 0 32px 64px -34px rgba(26, 188, 156, 0.55));
+            --df-upload-background: var(--upload-background, #101a2d);
+            --df-upload-border: var(--upload-border, rgba(26, 188, 156, 0.35));
+            --df-upload-text: var(--upload-text, #f8fafc);
             --df-warning-color: var(--warning, #FFC107);
             --df-error-color: #f87171;
         }
@@ -126,6 +129,12 @@ def apply_dark_theme() -> None:  # [ADDED]
             font-size: var(--df-font-caption);
             line-height: 1.55;
         }
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stCheckbox"] label p,
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stCheckbox"] label span,
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stRadio"] label p,
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stRadio"] label span {
+            color: var(--df-body-color) !important;
+        }
         div[data-testid="stAppViewContainer"] .main .block-container .stButton > button,
         div[data-testid="stAppViewContainer"] .main .block-container .stDownloadButton > button,
         div[data-testid="stAppViewContainer"] .main .block-container .stFormSubmitButton > button {
@@ -148,6 +157,52 @@ def apply_dark_theme() -> None:  # [ADDED]
         div[data-testid="stAppViewContainer"] .main .block-container .stFormSubmitButton > button:hover {
             transform: translateY(-1px) scale(1.02);
             box-shadow: 0 26px 48px -24px var(--df-button-shadow);
+        }
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stFileUploader"] > label {
+            color: var(--df-label-color) !important;
+            font-weight: 600;
+            font-size: var(--df-font-label);
+            margin-bottom: 0.6rem;
+        }
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stFileUploader"] section[data-testid="stFileUploaderDropzone"] {
+            background: var(--df-upload-background);
+            border: 1.5px dashed var(--df-upload-border);
+            border-radius: 18px;
+            color: var(--df-upload-text);
+            padding: 1.35rem 1.1rem;
+            transition: border-color 0.25s ease, box-shadow 0.25s ease,
+                background 0.25s ease;
+        }
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stFileUploader"] section[data-testid="stFileUploaderDropzone"]:hover {
+            border-color: var(--df-button-gradient-start);
+            box-shadow: var(--df-button-shadow);
+        }
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stFileUploader"] section[data-testid="stFileUploaderDropzone"] span,
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stFileUploader"] section[data-testid="stFileUploaderDropzone"] p,
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stFileUploader"] section[data-testid="stFileUploaderDropzone"] small {
+            color: var(--df-upload-text) !important;
+        }
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stFileUploader"] section[data-testid="stFileUploaderDropzone"] button {
+            background: linear-gradient(135deg, var(--df-button-gradient-start), var(--df-button-gradient-end));
+            color: #ffffff;
+            border: none;
+            border-radius: 12px;
+            font-weight: 600;
+            padding: 0.55rem 1.2rem;
+            box-shadow: var(--df-button-shadow);
+        }
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stFileUploader"] section[data-testid="stFileUploaderDropzone"] button:hover {
+            filter: brightness(1.05);
+        }
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stFileUploader"] .uploadedFile {
+            background: var(--app-surface-muted, #101a30);
+            border: 1px solid var(--muted-border, #3b4f6d);
+            border-radius: 12px;
+            color: var(--df-body-color);
+        }
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stFileUploader"] .uploadedFile span,
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stFileUploader"] .uploadedFile small {
+            color: var(--df-body-color) !important;
         }
         div[data-testid="stAppViewContainer"] .main .block-container .stAlert {
             border-radius: 16px;

--- a/unified_ui/app.py
+++ b/unified_ui/app.py
@@ -839,9 +839,11 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
             display: flex;
             flex-direction: column;
             align-items: center;
+            justify-content: center;
             text-align: center;
             gap: 1rem;
             margin-top: 1.5rem;
+            margin-inline: auto;
         }}
 
         .feature-card:hover {{
@@ -857,7 +859,7 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
             align-items: center;
             justify-content: center;
             font-size: 1.6rem;
-            margin-bottom: 1.15rem;
+            margin: 0 auto 1.15rem;
             background: linear-gradient(135deg, var(--primary), var(--primary-hover));
             color: #ffffff;
             box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
@@ -936,6 +938,67 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
 
         .path-preview--empty .path-preview__path {{
             color: var(--text-body);
+        }}
+
+        div[data-testid="stCheckbox"] label p,
+        div[data-testid="stCheckbox"] label span,
+        div[data-testid="stRadio"] label p,
+        div[data-testid="stRadio"] label span {{
+            color: var(--text-body) !important;
+        }}
+
+        div[data-testid="stFileUploader"] > label {{
+            color: var(--text-label) !important;
+            font-weight: 600;
+            font-size: var(--font-label);
+            margin-bottom: 0.6rem;
+        }}
+
+        div[data-testid="stFileUploader"] section[data-testid="stFileUploaderDropzone"] {{
+            background: var(--upload-background);
+            border: 1.5px dashed var(--upload-border);
+            border-radius: 18px;
+            color: var(--upload-text);
+            padding: 1.35rem 1.1rem;
+            transition: border-color 0.25s ease, box-shadow 0.25s ease,
+                background 0.25s ease;
+        }}
+
+        div[data-testid="stFileUploader"] section[data-testid="stFileUploaderDropzone"]:hover {{
+            border-color: var(--primary);
+            box-shadow: var(--hover-glow);
+        }}
+
+        div[data-testid="stFileUploader"] section[data-testid="stFileUploaderDropzone"] span,
+        div[data-testid="stFileUploader"] section[data-testid="stFileUploaderDropzone"] p,
+        div[data-testid="stFileUploader"] section[data-testid="stFileUploaderDropzone"] small {{
+            color: var(--upload-text) !important;
+        }}
+
+        div[data-testid="stFileUploader"] section[data-testid="stFileUploaderDropzone"] button {{
+            background: linear-gradient(135deg, var(--secondary-start), var(--secondary-end));
+            color: #ffffff;
+            border: none;
+            border-radius: 12px;
+            font-weight: 600;
+            padding: 0.55rem 1.2rem;
+            box-shadow: var(--hover-glow);
+        }}
+
+        div[data-testid="stFileUploader"] section[data-testid="stFileUploaderDropzone"] button:hover {{
+            filter: brightness(1.05);
+        }}
+
+        div[data-testid="stFileUploader"] .uploadedFile {{
+            background: var(--app-surface-muted);
+            border: 1px solid var(--muted-border);
+            border-radius: 12px;
+            color: var(--text-body);
+        }}
+
+        div[data-testid="stFileUploader"] .uploadedFile span,
+        div[data-testid="stFileUploader"] .uploadedFile small {{
+            color: var(--text-body) !important;
         }}
 
         hr {{


### PR DESCRIPTION
## Summary
- center the hero feature cards so icons and text align evenly across brands
- restyle checkbox, radio, and file uploader typography to stay readable in dark mode
- reuse the same upload styling within the Fortinet standalone dark theme helper

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d106e389448320848a17fe9444e633

## Sourcery 总结

居中 hero 特性卡片，并优化跨主题的表单控件和文件上传器的深色模式样式。

优化内容：
- 使用更新的 CSS 居中特性卡片，以实现均衡对齐
- 重新设计复选框和单选按钮的深色模式排版，以保持可读性
- 增强文件上传器深色模式下的用户界面，统一标签、拖放区、按钮和已上传文件的样式
- 通过共享 CSS 变量，在 Fortinet 独立深色主题中复用文件上传器样式

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Center hero feature cards and improve dark mode styling for form controls and file uploader across themes

Enhancements:
- Center feature cards with updated CSS for balanced alignment
- Restyle dark mode typography for checkboxes and radio buttons to maintain readability
- Enhance file uploader dark mode UI with consistent label, dropzone, button, and uploaded file styling
- Reuse file uploader styling in the Fortinet standalone dark theme via shared CSS variables

</details>