### PR TITLE
Adjust theme toggle placement and dark mode styling

### DIFF
--- a/Cisco_ui/ui_pages/log_monitor.py
+++ b/Cisco_ui/ui_pages/log_monitor.py
@@ -447,16 +447,14 @@ def render_directory_selector(
         st.session_state[display_key] = st.session_state[session_key]
 
     current_path = st.session_state[session_key]
-    columns = st.columns([4.2, 1.1])
-    with columns[0]:
+    with st.container():
         st.text_input(
             label,
             value=st.session_state[display_key],
             key=display_key,
             disabled=True,
-            placeholder="使用右側瀏覽按鈕選擇資料夾",
+            placeholder="使用下方瀏覽按鈕選擇資料夾",
         )
-    with columns[1]:
         uploaded_files = st.file_uploader(
             "瀏覽",
             key=f"{session_key}_uploader",

--- a/Cisco_ui/ui_pages/visualization.py
+++ b/Cisco_ui/ui_pages/visualization.py
@@ -31,7 +31,8 @@ def app() -> None:
     folder = st.text_input("圖表資料夾", value=_get_folder())
     st.session_state["cisco_visual_folder"] = folder
 
-    if st.button("同步自動清洗輸出路徑"):
+    center_cols = st.columns([1, 0.6, 1])
+    if center_cols[1].button("同步自動清洗輸出路徑", use_container_width=True):
         monitor = get_log_monitor()
         st.session_state["cisco_visual_folder"] = monitor.settings.get("clean_csv_dir", "")
         st.experimental_rerun()

--- a/Forti_ui_app_bundle/ui_pages/visualization_ui.py
+++ b/Forti_ui_app_bundle/ui_pages/visualization_ui.py
@@ -32,24 +32,32 @@ def app() -> None:
             margin-top: 1rem;
             padding: 1.25rem 1.5rem;
             border-radius: 18px;
-            border: 1px solid rgba(148, 163, 184, 0.25);
-            background: linear-gradient(135deg, rgba(255, 255, 255, 0.98), rgba(226, 232, 240, 0.82));
-            box-shadow: 0 22px 45px -28px rgba(30, 41, 59, 0.55);
+            border: 1px solid var(--muted-border, rgba(148, 163, 184, 0.35));
+            background: var(--app-surface-muted, rgba(15, 23, 42, 0.82));
+            box-shadow: var(--df-button-shadow, 0 22px 45px -28px rgba(30, 41, 59, 0.55));
         }
         .viz-card--inline {
             display: inline-flex;
             align-items: center;
             gap: 0.65rem;
             margin-top: 0;
+            background: var(--app-surface, rgba(15, 23, 42, 0.65));
+            border: 1px solid var(--muted-border, rgba(148, 163, 184, 0.35));
+            padding: 0.7rem 1rem;
+            border-radius: 14px;
+            box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+        }
+        .viz-card--inline strong {
+            color: var(--df-title-color);
         }
         .viz-chart-title {
             font-weight: 600;
             font-size: 1.05rem;
             margin-bottom: 0.85rem;
-            color: #0f172a;
+            color: var(--df-title-color);
         }
         .viz-hint {
-            color: #64748b;
+            color: var(--df-caption-color);
             font-size: 0.9rem;
             margin-top: 0.35rem;
         }

--- a/unified_ui/app.py
+++ b/unified_ui/app.py
@@ -396,6 +396,38 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
             margin-bottom: 1.4rem;
         }}
 
+        div[data-testid="stSidebar"] .sidebar-toggle-wrapper {{
+            display: inline-flex;
+            width: 100%;
+            align-items: center;
+            justify-content: flex-end;
+            margin-bottom: 0.35rem;
+            padding-top: 0.15rem;
+        }}
+
+        div[data-testid="stSidebar"] .sidebar-toggle-wrapper div[data-testid="stToggle"] {{
+            margin: 0;
+        }}
+
+        div[data-testid="stSidebar"] .sidebar-toggle-wrapper label {{
+            display: inline-flex;
+            align-items: center;
+            gap: 0.4rem;
+            font-weight: 600;
+            color: var(--sidebar-text);
+            font-size: 0.95rem;
+        }}
+
+        div[data-testid="stSidebar"] .sidebar-toggle-wrapper [data-baseweb="toggle"] {{
+            background-color: rgba(139, 233, 221, 0.2);
+            border-radius: 999px;
+            transition: background-color 0.25s ease;
+        }}
+
+        div[data-testid="stSidebar"] .sidebar-toggle-wrapper [data-baseweb="toggle"][aria-checked="true"] {{
+            background-color: rgba(26, 188, 156, 0.75);
+        }}
+
         div[data-testid="stSidebar"] .sidebar-eyebrow {{
             display: inline-flex;
             align-items: center;
@@ -1101,6 +1133,18 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
 def _render_sidebar(current_theme: str) -> str:
     options = list(BRAND_RENDERERS.keys())
     with st.sidebar:
+        toggle_cols = st.columns([1, 0.42])
+        with toggle_cols[1]:
+            emoji = "🌙" if current_theme == "dark" else "🌞"
+            st.markdown("<div class='sidebar-toggle-wrapper'>", unsafe_allow_html=True)
+            is_dark = st.toggle(
+                f"{emoji} 深色介面",
+                value=current_theme == "dark",
+                key="unified_theme_toggle",
+                help="切換深色 / 淺色介面",
+            )
+            st.markdown("</div>", unsafe_allow_html=True)
+
         st.markdown(
             f"""
             <div class="sidebar-heading">
@@ -1112,7 +1156,6 @@ def _render_sidebar(current_theme: str) -> str:
             unsafe_allow_html=True,
         )
 
-        is_dark = st.toggle("深色介面", value=current_theme == "dark", key="unified_theme_toggle")
         st.session_state["unified_theme"] = "dark" if is_dark else "light"
 
         brand = st.selectbox("選擇品牌", options, key="unified_brand")


### PR DESCRIPTION
## Summary
- move the unified console theme toggle to the sidebar header, add sun/moon labels, and style the control to match the sidebar theme
- stack the Cisco directory selector uploader beneath the path field and update the placeholder copy
- center the standalone visualization sync button and refresh Fortinet visualization cards to honour dark mode colors

## Testing
- python -m compileall unified_ui Cisco_ui Forti_ui_app_bundle

------
https://chatgpt.com/codex/tasks/task_e_68d10bb1025083209b45077cf2ed3e9e

## Sourcery 摘要

调整统一、Cisco 和 Fortinet 应用程序中的 UI 组件，以改进主题切换器的位置、目录选择器的布局和暗模式的样式。

增强：
- 重新定位并重新设计统一控制台侧边栏标题中的主题切换器样式，并带有太阳/月亮标签
- 将 Cisco 目录选择器上传器堆叠在路径字段下方，并更新其占位符文本
- 将 Cisco UI 中独立的可视化同步按钮居中
- 更新 Fortinet 可视化卡片，使其使用 CSS 变量以实现暗模式友好的样式

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust UI components across the unified, Cisco, and Fortinet applications to improve theme toggle placement, directory selector layout, and dark mode styling

Enhancements:
- Relocate and restyle unified console theme toggle in the sidebar header with sun/moon labels
- Stack the Cisco directory selector uploader below the path field and update its placeholder text
- Center the standalone visualization sync button in the Cisco UI
- Update Fortinet visualization cards to use CSS variables for dark mode-friendly styling

</details>