### PR TITLE
Fix dark mode typography overrides and update theme toggle label

### DIFF
--- a/Forti_ui_app_bundle/ui_pages/__init__.py
+++ b/Forti_ui_app_bundle/ui_pages/__init__.py
@@ -69,21 +69,23 @@ def apply_dark_theme() -> None:  # [ADDED]
             --df-error-color: #f87171;
         }
         div[data-testid="stAppViewContainer"] .main .block-container {
-            color: var(--df-body-color);
+            color: var(--df-body-color) !important;
             font-size: var(--df-font-body);
             line-height: 1.65;
         }
         div[data-testid="stAppViewContainer"] .main .block-container h1,
-        div[data-testid="stAppViewContainer"] .main .block-container .stMarkdown h1 {
-            color: var(--df-title-color);
+        div[data-testid="stAppViewContainer"] .main .block-container .stMarkdown h1,
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stMarkdownContainer"] h1 {
+            color: var(--df-title-color) !important;
             font-size: var(--df-font-h1);
             font-weight: 700;
             margin-top: 0;
             margin-bottom: 0.75rem;
         }
         div[data-testid="stAppViewContainer"] .main .block-container h2,
-        div[data-testid="stAppViewContainer"] .main .block-container .stMarkdown h2 {
-            color: var(--df-heading2-color);
+        div[data-testid="stAppViewContainer"] .main .block-container .stMarkdown h2,
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stMarkdownContainer"] h2 {
+            color: var(--df-heading2-color) !important;
             font-size: var(--df-font-h2);
             font-weight: 600;
             margin-top: 2.1rem;
@@ -92,8 +94,10 @@ def apply_dark_theme() -> None:  # [ADDED]
         div[data-testid="stAppViewContainer"] .main .block-container h3,
         div[data-testid="stAppViewContainer"] .main .block-container h4,
         div[data-testid="stAppViewContainer"] .main .block-container .stMarkdown h3,
-        div[data-testid="stAppViewContainer"] .main .block-container .stMarkdown h4 {
-            color: var(--df-heading3-color);
+        div[data-testid="stAppViewContainer"] .main .block-container .stMarkdown h4,
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stMarkdownContainer"] h3,
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stMarkdownContainer"] h4 {
+            color: var(--df-heading3-color) !important;
             font-size: var(--df-font-h3);
             font-weight: 600;
             margin-top: 1.7rem;
@@ -103,7 +107,7 @@ def apply_dark_theme() -> None:  # [ADDED]
         div[data-testid="stAppViewContainer"] .main .block-container h6,
         div[data-testid="stAppViewContainer"] .main .block-container .stMarkdown h5,
         div[data-testid="stAppViewContainer"] .main .block-container .stMarkdown h6 {
-            color: var(--df-label-color);
+            color: var(--df-label-color) !important;
             font-size: calc(var(--df-font-label) - 1px);
             font-weight: 600;
             text-transform: uppercase;
@@ -114,13 +118,29 @@ def apply_dark_theme() -> None:  # [ADDED]
         div[data-testid="stAppViewContainer"] .main .block-container p,
         div[data-testid="stAppViewContainer"] .main .block-container span,
         div[data-testid="stAppViewContainer"] .main .block-container li {
-            color: var(--df-body-color);
+            color: var(--df-body-color) !important;
             font-size: var(--df-font-body);
         }
         div[data-testid="stAppViewContainer"] .main .block-container label {
-            color: var(--df-label-color);
+            color: var(--df-label-color) !important;
             font-size: var(--df-font-label);
             font-weight: 500;
+        }
+        div[data-testid="stAppViewContainer"] .main .block-container label span,
+        div[data-testid="stAppViewContainer"] .main .block-container label p {
+            color: var(--df-label-color) !important;
+        }
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stMarkdownContainer"] > * {
+            color: var(--df-body-color) !important;
+        }
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stSelectbox"] label,
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stSelectbox"] label span,
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stSelectbox"] label p {
+            color: var(--df-label-color) !important;
+        }
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stSelectbox"] div[data-baseweb="select"] *,
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stSelectbox"] div[data-baseweb="select"] input {
+            color: var(--df-title-color) !important;
         }
         div[data-testid="stAppViewContainer"] .main .block-container small,
         div[data-testid="stAppViewContainer"] .main .block-container .stCaption,
@@ -168,7 +188,7 @@ def apply_dark_theme() -> None:  # [ADDED]
             background: var(--df-upload-background);
             border: 1.5px dashed var(--df-upload-border);
             border-radius: 18px;
-            color: var(--df-upload-text);
+            color: var(--df-upload-text) !important;
             padding: 1.35rem 1.1rem;
             transition: border-color 0.25s ease, box-shadow 0.25s ease,
                 background 0.25s ease;
@@ -198,7 +218,7 @@ def apply_dark_theme() -> None:  # [ADDED]
             background: var(--app-surface-muted, #101a30);
             border: 1px solid var(--muted-border, #3b4f6d);
             border-radius: 12px;
-            color: var(--df-body-color);
+            color: var(--df-body-color) !important;
         }
         div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stFileUploader"] .uploadedFile span,
         div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stFileUploader"] .uploadedFile small {
@@ -211,7 +231,7 @@ def apply_dark_theme() -> None:  # [ADDED]
             box-shadow: var(--df-button-shadow);
         }
         div[data-testid="stAppViewContainer"] .main .block-container .stAlert div[role="alert"] p {
-            color: var(--df-body-color);
+            color: var(--df-body-color) !important;
         }
         div[data-testid="stAppViewContainer"] .main .block-container .stAlert[data-baseweb="alert"][kind="warning"] div[data-testid="stMarkdownContainer"] p {
             color: var(--df-warning-color) !important;
@@ -221,7 +241,7 @@ def apply_dark_theme() -> None:  # [ADDED]
         }
         div[data-testid="stAppViewContainer"] .main .block-container pre,
         div[data-testid="stAppViewContainer"] .main .block-container code {
-            color: var(--df-body-color);
+            color: var(--df-body-color) !important;
             background: var(--code-background, #0b1220);
             border-radius: 12px;
             padding: 0.25rem 0.5rem;

--- a/unified_ui/app.py
+++ b/unified_ui/app.py
@@ -263,7 +263,7 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
         }}
 
         body {{
-            color: var(--text-body);
+            color: var(--text-body) !important;
             font-family: "Noto Sans TC", "Inter", "Segoe UI", system-ui, -apple-system,
                 BlinkMacSystemFont, sans-serif;
             font-size: var(--font-body);
@@ -271,7 +271,7 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
         }}
 
         div[data-testid="stAppViewContainer"] .main .block-container {{
-            color: var(--text-body);
+            color: var(--text-body) !important;
             font-size: var(--font-body);
             line-height: 1.65;
         }}
@@ -282,13 +282,13 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
         div[data-testid="stAppViewContainer"] .main .block-container label,
         div[data-testid="stAppViewContainer"] .main .block-container .stMarkdown p,
         div[data-testid="stAppViewContainer"] .main .block-container .stMarkdown li {{
-            color: var(--text-body);
+            color: var(--text-body) !important;
             font-size: var(--font-body);
         }}
 
         div[data-testid="stAppViewContainer"] .main .block-container h1,
         div[data-testid="stAppViewContainer"] .main .block-container .stMarkdown h1 {{
-            color: var(--text-h1);
+            color: var(--text-h1) !important;
             font-size: var(--font-h1);
             font-weight: 700;
             letter-spacing: 0.01em;
@@ -298,7 +298,7 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
 
         div[data-testid="stAppViewContainer"] .main .block-container h2,
         div[data-testid="stAppViewContainer"] .main .block-container .stMarkdown h2 {{
-            color: var(--text-h2);
+            color: var(--text-h2) !important;
             font-size: var(--font-h2);
             font-weight: 600;
             margin-top: 2.2rem;
@@ -309,7 +309,7 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
         div[data-testid="stAppViewContainer"] .main .block-container h4,
         div[data-testid="stAppViewContainer"] .main .block-container .stMarkdown h3,
         div[data-testid="stAppViewContainer"] .main .block-container .stMarkdown h4 {{
-            color: var(--text-h3);
+            color: var(--text-h3) !important;
             font-size: var(--font-h3);
             font-weight: 600;
             margin-top: 1.8rem;
@@ -320,7 +320,7 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
         div[data-testid="stAppViewContainer"] .main .block-container h6,
         div[data-testid="stAppViewContainer"] .main .block-container .stMarkdown h5,
         div[data-testid="stAppViewContainer"] .main .block-container .stMarkdown h6 {{
-            color: var(--text-label);
+            color: var(--text-label) !important;
             font-size: calc(var(--font-label) - 1px);
             font-weight: 600;
             text-transform: uppercase;
@@ -900,13 +900,13 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
         .feature-card__title {{
             font-size: var(--font-h3);
             font-weight: 700;
-            color: var(--text-h3);
+            color: var(--text-h3) !important;
             margin-bottom: 0.25rem;
             text-align: center;
         }}
 
         .feature-card__desc {{
-            color: var(--text-body);
+            color: var(--text-body) !important;
             margin: 0;
             font-size: calc(var(--font-body) - 0.3px);
             line-height: 1.65;
@@ -946,12 +946,12 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
 
         .path-preview__label {{
             font-weight: 600;
-            color: var(--text-label);
+            color: var(--text-label) !important;
             font-size: calc(var(--font-label) - 1px);
         }}
 
         .path-preview__path {{
-            color: var(--text-body);
+            color: var(--text-body) !important;
             font-family: "JetBrains Mono", "Roboto Mono", monospace;
             font-size: calc(var(--font-body) - 1px);
             word-break: break-all;
@@ -965,11 +965,11 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
 
         .path-preview--empty .path-preview__icon {{
             background: rgba(148, 163, 184, 0.2);
-            color: var(--text-secondary);
+            color: var(--text-secondary) !important;
         }}
 
         .path-preview--empty .path-preview__path {{
-            color: var(--text-body);
+            color: var(--text-body) !important;
         }}
 
         div[data-testid="stCheckbox"] label p,
@@ -990,7 +990,7 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
             background: var(--upload-background);
             border: 1.5px dashed var(--upload-border);
             border-radius: 18px;
-            color: var(--upload-text);
+            color: var(--upload-text) !important;
             padding: 1.35rem 1.1rem;
             transition: border-color 0.25s ease, box-shadow 0.25s ease,
                 background 0.25s ease;
@@ -1025,7 +1025,7 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
             background: var(--app-surface-muted);
             border: 1px solid var(--muted-border);
             border-radius: 12px;
-            color: var(--text-body);
+            color: var(--text-body) !important;
         }}
 
         div[data-testid="stFileUploader"] .uploadedFile span,
@@ -1046,7 +1046,7 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
         }}
 
         .stAlert div[role="alert"] p {{
-            color: var(--text-body);
+            color: var(--text-body) !important;
         }}
 
         .stAlert[data-baseweb="alert"][kind="warning"] {{
@@ -1059,7 +1059,7 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
 
         code, pre {{
             background: var(--code-background);
-            color: var(--text-body);
+            color: var(--text-body) !important;
             border-radius: 10px;
             padding: 0.2rem 0.45rem;
         }}
@@ -1119,7 +1119,7 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
 
         div[data-testid="stJson"] pre {{
             background: var(--code-background);
-            color: var(--text-body);
+            color: var(--text-body) !important;
             border-radius: 16px;
             padding: 1.1rem 1.25rem;
             font-size: calc(var(--font-body) - 0.2px);
@@ -1138,7 +1138,7 @@ def _render_sidebar(current_theme: str) -> str:
             emoji = "🌙" if current_theme == "dark" else "🌞"
             st.markdown("<div class='sidebar-toggle-wrapper'>", unsafe_allow_html=True)
             is_dark = st.toggle(
-                f"{emoji} 深色介面",
+                emoji,
                 value=current_theme == "dark",
                 key="unified_theme_toggle",
                 help="切換深色 / 淺色介面",


### PR DESCRIPTION
## Summary
- enforce dark theme typography overrides with !important flags so that body, heading, card and form text respect the active palette
- ensure Fortinet UI pages reuse the same enforced colors for uploader, alerts and code blocks to avoid grey text in dark mode
- simplify the sidebar theme toggle label to display only the emoji as requested
- ensure the Training Pipeline title and select inputs also adopt the enforced white typography when dark mode is active

## Testing
- python -m compileall unified_ui Forti_ui_app_bundle

------
https://chatgpt.com/codex/tasks/task_e_68d11288ca648320ba71157b1415d268