### PR TITLE
Force dark mode fallbacks to white text

### DIFF
--- a/Cisco_ui/ui_app.py
+++ b/Cisco_ui/ui_app.py
@@ -1,6 +1,8 @@
 """Cisco Streamlit 主介面。"""
 from __future__ import annotations
 
+from typing import Callable, Mapping
+
 import streamlit as st
 from streamlit.errors import StreamlitAPIException
 
@@ -18,6 +20,7 @@ if __package__ in (None, ""):
         sys.path.insert(0, str(_MODULE_ROOT))
 
     from ui_pages import (  # type: ignore[import]
+        apply_dark_theme,
         data_cleaning,
         log_monitor,
         model_inference,
@@ -26,6 +29,7 @@ if __package__ in (None, ""):
     )
 else:
     from .ui_pages import (
+        apply_dark_theme,
         data_cleaning,
         log_monitor,
         model_inference,
@@ -33,13 +37,26 @@ else:
         visualization,
     )
 
-PAGES = {
+
+def _with_theme(page_fn: Callable[[], None]) -> Callable[[], None]:
+    """Wrap page callbacks so brand styling is applied once per render."""
+
+    def _rendered() -> None:
+        apply_dark_theme()
+        page_fn()
+
+    return _rendered
+
+
+_RAW_PAGES: Mapping[str, Callable[[], None]] = {
     "通知模組": notifications.app,
     "Log 擷取": log_monitor.app,
     "模型推論": model_inference.app,
     "圖表預覽": visualization.app,
     "資料清理": data_cleaning.app,
 }
+
+PAGES = {name: _with_theme(page) for name, page in _RAW_PAGES.items()}
 PAGE_EMOJIS = {
     "通知模組": "🔔",
     "Log 擷取": "📄",
@@ -81,18 +98,23 @@ def _render_sidebar() -> str:
         <style>
         div[data-testid="stSidebar"] {{
             width: {sidebar_width};
-            background-color: #0f172a;
+            background-color: var(--sidebar-bg, #0f172a);
             transition: width 0.3s ease;
         }}
         div[data-testid="stSidebar"] .nav-link {{
-            color: #e2e8f0;
+            color: var(--sidebar-text, #ffffff);
         }}
         div[data-testid="stSidebar"] .nav-link:hover {{
-            background-color: #1e293b;
+            background-color: var(--sidebar-button-hover, #1e293b);
         }}
         div[data-testid="stSidebar"] .nav-link-selected {{
-            background-color: #2563eb;
+            background: linear-gradient(135deg, var(--primary, #2563eb), var(--primary-hover, #38bdf8));
             color: #ffffff;
+        }}
+        div[data-testid="stSidebar"] .stMarkdown,
+        div[data-testid="stSidebar"] .stCaption,
+        div[data-testid="stSidebar"] p {{
+            color: var(--sidebar-text, #ffffff) !important;
         }}
         .menu-collapsed .nav-link span {{
             display: none;
@@ -123,16 +145,19 @@ def _render_sidebar() -> str:
                 menu_icon="list",
                 default_index=0,
                 styles={
-                    "container": {"padding": "0", "background-color": "#0f172a"},
-                    "icon": {"color": "white", "font-size": "16px"},
+                    "container": {"padding": "0", "background-color": "var(--sidebar-bg, #0f172a)"},
+                    "icon": {"color": "var(--sidebar-icon, #ffffff)", "font-size": "16px"},
                     "nav-link": {
-                        "color": "#cbd5f5",
+                        "color": "var(--sidebar-text, #ffffff)",
                         "font-size": "15px",
                         "text-align": "left",
                         "margin": "0px",
-                        "--hover-color": "#1e293b",
+                        "--hover-color": "var(--sidebar-button-hover, #1e293b)",
                     },
-                    "nav-link-selected": {"background-color": "#1d4ed8"},
+                    "nav-link-selected": {
+                        "background-color": "var(--primary, #1d4ed8)",
+                        "color": "#ffffff",
+                    },
                 },
             )
             st.markdown("</div>", unsafe_allow_html=True)

--- a/Cisco_ui/ui_pages/__init__.py
+++ b/Cisco_ui/ui_pages/__init__.py
@@ -1,4 +1,8 @@
-"""Cisco UI 頁面模組集合。"""
+"""Cisco UI 頁面模組集合與樣式工具。"""
+from __future__ import annotations
+
+import streamlit as st
+
 from .data_cleaning import app as data_cleaning_app
 from .log_monitor import app as log_monitor_app
 from .model_inference import app as model_inference_app
@@ -6,9 +10,189 @@ from .notifications import app as notifications_app
 from .visualization import app as visualization_app
 
 __all__ = [
+    "apply_dark_theme",
     "data_cleaning_app",
     "log_monitor_app",
     "model_inference_app",
     "notifications_app",
     "visualization_app",
 ]
+
+
+def apply_dark_theme() -> None:
+    """Inject consistent typography and contrast-aware component styling."""
+
+    if st.session_state.get("_cisco_dark_theme_applied"):
+        return
+
+    st.session_state["_cisco_dark_theme_applied"] = True
+    st.markdown(
+        """
+        <style>
+        :root {
+            --cisco-title-color: var(--text-h1, #ffffff);
+            --cisco-heading2-color: var(--text-h2, #ffffff);
+            --cisco-heading3-color: var(--text-h3, #ffffff);
+            --cisco-body-color: var(--text-body, #ffffff);
+            --cisco-caption-color: var(--text-on-dark, var(--cisco-body-color));
+            --cisco-label-color: var(--text-label, #ffffff);
+            --cisco-font-h1: var(--font-h1, 26px);
+            --cisco-font-h2: var(--font-h2, 22px);
+            --cisco-font-h3: var(--font-h3, 18px);
+            --cisco-font-label: var(--font-label, 16px);
+            --cisco-font-body: var(--font-body, 15.5px);
+            --cisco-font-caption: var(--font-caption, 13.5px);
+            --cisco-button-gradient-start: var(--primary, #2563eb);
+            --cisco-button-gradient-end: var(--primary-hover, #38bdf8);
+            --cisco-button-shadow: var(--hover-glow, 0 32px 64px -34px rgba(37, 99, 235, 0.55));
+            --cisco-upload-background: var(--upload-background, #101a2d);
+            --cisco-upload-border: var(--upload-border, rgba(37, 99, 235, 0.35));
+            --cisco-upload-text: var(--text-on-dark, var(--cisco-body-color));
+        }
+
+        div[data-testid="stAppViewContainer"] .main .block-container {
+            color: var(--cisco-body-color) !important;
+            font-size: var(--cisco-font-body);
+            line-height: 1.65;
+        }
+
+        div[data-testid="stAppViewContainer"] .main .block-container h1,
+        div[data-testid="stAppViewContainer"] .main .block-container .stMarkdown h1 {
+            color: var(--cisco-title-color) !important;
+            font-size: var(--cisco-font-h1);
+            font-weight: 700;
+            margin-top: 0;
+            margin-bottom: 0.75rem;
+        }
+
+        div[data-testid="stAppViewContainer"] .main .block-container h2,
+        div[data-testid="stAppViewContainer"] .main .block-container .stMarkdown h2 {
+            color: var(--cisco-heading2-color) !important;
+            font-size: var(--cisco-font-h2);
+            font-weight: 600;
+            margin-top: 2.1rem;
+            margin-bottom: 0.7rem;
+        }
+
+        div[data-testid="stAppViewContainer"] .main .block-container h3,
+        div[data-testid="stAppViewContainer"] .main .block-container h4,
+        div[data-testid="stAppViewContainer"] .main .block-container .stMarkdown h3,
+        div[data-testid="stAppViewContainer"] .main .block-container .stMarkdown h4 {
+            color: var(--cisco-heading3-color) !important;
+            font-size: var(--cisco-font-h3);
+            font-weight: 600;
+            margin-top: 1.7rem;
+            margin-bottom: 0.6rem;
+        }
+
+        div[data-testid="stAppViewContainer"] .main .block-container h5,
+        div[data-testid="stAppViewContainer"] .main .block-container h6,
+        div[data-testid="stAppViewContainer"] .main .block-container .stMarkdown h5,
+        div[data-testid="stAppViewContainer"] .main .block-container .stMarkdown h6 {
+            color: var(--cisco-label-color) !important;
+            font-size: calc(var(--cisco-font-label) - 1px);
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            margin-top: 1.5rem;
+            margin-bottom: 0.45rem;
+        }
+
+        div[data-testid="stAppViewContainer"] .main .block-container p,
+        div[data-testid="stAppViewContainer"] .main .block-container span,
+        div[data-testid="stAppViewContainer"] .main .block-container li,
+        div[data-testid="stAppViewContainer"] .main .block-container label,
+        div[data-testid="stAppViewContainer"] .main .block-container .stMarkdown p,
+        div[data-testid="stAppViewContainer"] .main .block-container .stMarkdown li {
+            color: var(--cisco-body-color) !important;
+            font-size: var(--cisco-font-body);
+        }
+
+        div[data-testid="stAppViewContainer"] ::placeholder {
+            color: var(--cisco-body-color) !important;
+            opacity: 1;
+        }
+
+        div[data-testid="stAppViewContainer"] .main .block-container label {
+            color: var(--cisco-label-color) !important;
+            font-size: var(--cisco-font-label);
+            font-weight: 500;
+        }
+
+        div[data-testid="stAppViewContainer"] .main .block-container small,
+        div[data-testid="stAppViewContainer"] .main .block-container .stCaption,
+        div[data-testid="stAppViewContainer"] .main .block-container .caption {
+            color: var(--cisco-caption-color) !important;
+            font-size: var(--cisco-font-caption);
+            line-height: 1.55;
+        }
+
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-baseweb="input"] input,
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-baseweb="input"] textarea,
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stSelectbox"] div[data-baseweb="select"] * {
+            background: var(--input-background, #0a121f) !important;
+            color: var(--cisco-title-color) !important;
+            border-color: var(--input-border, #3b4f6d) !important;
+        }
+
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stSelectbox"] label,
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stRadio"] label,
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stCheckbox"] label {
+            color: var(--cisco-label-color) !important;
+        }
+
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stFileUploader"] > label {
+            color: var(--cisco-label-color) !important;
+            font-weight: 600;
+            font-size: var(--cisco-font-label);
+            margin-bottom: 0.6rem;
+        }
+
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stFileUploader"] section[data-testid="stFileUploaderDropzone"] {
+            background: var(--cisco-upload-background);
+            border: 1.5px dashed var(--cisco-upload-border);
+            border-radius: 18px;
+            color: var(--cisco-upload-text) !important;
+            padding: 1.35rem 1.1rem;
+            transition: border-color 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+        }
+
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stFileUploader"] section[data-testid="stFileUploaderDropzone"] span,
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stFileUploader"] section[data-testid="stFileUploaderDropzone"] p,
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stFileUploader"] section[data-testid="stFileUploaderDropzone"] small {
+            color: var(--cisco-upload-text) !important;
+        }
+
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stFileUploader"] button {
+            background: linear-gradient(135deg, var(--cisco-button-gradient-start), var(--cisco-button-gradient-end));
+            color: #ffffff;
+            border: none;
+            border-radius: 12px;
+            font-weight: 600;
+            padding: 0.55rem 1.2rem;
+            box-shadow: var(--cisco-button-shadow);
+        }
+
+        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stFileUploader"] .uploadedFile,
+        div[data-testid="stAppViewContainer"] .main .block-container .stAlert {
+            background: var(--app-surface-muted, #101a30);
+            border: 1px solid var(--muted-border, #3b4f6d);
+            color: var(--cisco-body-color) !important;
+        }
+
+        div[data-testid="stAppViewContainer"] .main .block-container .stButton > button,
+        div[data-testid="stAppViewContainer"] .main .block-container .stFormSubmitButton > button,
+        div[data-testid="stAppViewContainer"] .main .block-container .stDownloadButton > button {
+            background: linear-gradient(135deg, var(--cisco-button-gradient-start), var(--cisco-button-gradient-end));
+            color: #ffffff;
+            border: none;
+            border-radius: 14px;
+            font-size: var(--cisco-font-label);
+            font-weight: 600;
+            padding: 0.75rem 1.45rem;
+            box-shadow: var(--cisco-button-shadow);
+        }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )

--- a/Forti_ui_app_bundle/ui_app.py
+++ b/Forti_ui_app_bundle/ui_app.py
@@ -31,28 +31,30 @@ st.markdown(  # [MODIFIED]
     f"""
     <style>
     .stApp {{
-        background-color: #f5f7fa;
+        background-color: var(--app-bg, #f5f7fa);
     }}
     div[data-testid="stSidebar"] {{
         width: {sidebar_width};
-        background-color: #1f2937;
+        background-color: var(--sidebar-bg, #1f2937);
         transition: width 0.3s ease;
     }}
     div[data-testid="stSidebar"] .nav-link {{
-        color: #e5e7eb;
+        color: var(--sidebar-text, #ffffff);
     }}
     div[data-testid="stSidebar"] .nav-link:hover {{
-        background-color: #374151;
+        background-color: var(--sidebar-button-hover, #374151);
     }}
     div[data-testid="stSidebar"] .nav-link-selected {{
-        background-color: #2563eb;
+        background: linear-gradient(135deg, var(--primary, #2563eb), var(--primary-hover, #38bdf8));
         color: #ffffff;
     }}
     div[data-testid="stSidebar"] h1 {{
-        color: #f9fafb;
+        color: var(--sidebar-text, #ffffff);
     }}
+    div[data-testid="stSidebar"] .stMarkdown,
+    div[data-testid="stSidebar"] .stCaption,
     div[data-testid="stSidebar"] p {{
-        color: #d1d5db;
+        color: var(--sidebar-text, #ffffff) !important;
     }}
     .menu-expanded .nav-link span {{
         display: inline-block;
@@ -128,16 +130,19 @@ with st.sidebar:
                 menu_icon="cast",
                 default_index=0,
                 styles={
-                    "container": {"padding": "0", "background-color": "#1F2937"},
-                    "icon": {"color": "white", "font-size": "16px"},
+                    "container": {"padding": "0", "background-color": "var(--sidebar-bg, #1F2937)"},
+                    "icon": {"color": "var(--sidebar-icon, #ffffff)", "font-size": "16px"},
                     "nav-link": {
-                        "color": "#d1d5db",
+                        "color": "var(--sidebar-text, #ffffff)",
                         "font-size": "16px",
                         "text-align": "left",
                         "margin": "0px",
-                        "--hover-color": "#4b5563",
+                        "--hover-color": "var(--sidebar-button-hover, #4b5563)",
                     },
-                    "nav-link-selected": {"background-color": "#111827"},
+                    "nav-link-selected": {
+                        "background-color": "var(--primary, #111827)",
+                        "color": "#ffffff",
+                    },
                 },
             )
             st.markdown("</div>", unsafe_allow_html=True)

--- a/Forti_ui_app_bundle/ui_pages/__init__.py
+++ b/Forti_ui_app_bundle/ui_pages/__init__.py
@@ -51,7 +51,7 @@ def apply_dark_theme() -> None:  # [ADDED]
             --df-heading2-color: var(--text-h2, var(--text-primary, #ffffff));
             --df-heading3-color: var(--text-h3, var(--text-primary, #ffffff));
             --df-body-color: var(--text-body, #ffffff);
-            --df-caption-color: var(--text-caption, #ffffff);
+            --df-caption-color: var(--text-on-dark, var(--df-body-color));
             --df-label-color: var(--text-label, #ffffff);
             --df-font-h1: var(--font-h1, 26px);
             --df-font-h2: var(--font-h2, 22px);
@@ -64,7 +64,7 @@ def apply_dark_theme() -> None:  # [ADDED]
             --df-button-shadow: var(--hover-glow, 0 32px 64px -34px rgba(26, 188, 156, 0.55));
             --df-upload-background: var(--upload-background, #101a2d);
             --df-upload-border: var(--upload-border, rgba(26, 188, 156, 0.35));
-            --df-upload-text: var(--upload-text, #f8fafc);
+            --df-upload-text: var(--text-on-dark, var(--df-body-color));
             --df-warning-color: var(--warning, #FFC107);
             --df-error-color: #f87171;
         }
@@ -125,6 +125,11 @@ r
         div[data-testid="stAppViewContainer"] .main .block-container li {
             color: var(--df-body-color) !important;
             font-size: var(--df-font-body);
+        }
+
+        div[data-testid="stAppViewContainer"] ::placeholder {
+            color: var(--df-body-color) !important;
+            opacity: 1;
         }
         div[data-testid="stAppViewContainer"] .main .block-container label {
             color: var(--df-label-color) !important;

--- a/unified_ui/app.py
+++ b/unified_ui/app.py
@@ -286,6 +286,11 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
             font-size: var(--font-body);
         }}
 
+        div[data-testid="stAppViewContainer"] ::placeholder {{
+            color: var(--text-caption) !important;
+            opacity: 0.85;
+        }}
+
         div[data-testid="stAppViewContainer"] .main .block-container h1,
         div[data-testid="stAppViewContainer"] .main .block-container .stMarkdown h1 {{
             color: var(--text-h1) !important;
@@ -648,7 +653,7 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
         div[data-testid="stFileUploader"] section[data-testid="stFileUploaderDropzone"] {{
             border: 1px dashed var(--upload-border);
             background: var(--upload-background);
-            color: var(--upload-text);
+            color: var(--upload-text) !important;
             border-radius: 18px;
             padding: 1.25rem 1.35rem;
             box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
@@ -661,7 +666,12 @@ def _apply_theme_styles(palette: dict[str, str]) -> None:
         }}
 
         div[data-testid="stFileUploader"] section[data-testid="stFileUploaderDropzone"] span {{
-            color: var(--upload-text);
+            color: var(--upload-text) !important;
+        }}
+
+        div[data-testid="stFileUploader"] section[data-testid="stFileUploaderDropzone"] p,
+        div[data-testid="stFileUploader"] section[data-testid="stFileUploaderDropzone"] small {{
+            color: var(--upload-text) !important;
         }}
 
         div[data-testid="stFileUploader"] button {{


### PR DESCRIPTION
## Summary
- default Cisco page captions, placeholders, and uploader copy to the white body color so dark mode inputs no longer render gray
- default Fortinet captions, placeholders, and uploader text to the white body color for consistent contrast in dark mode
- update both brand sidebars to fall back to white navigation and helper text when theme variables are unavailable

## Testing
- python -m compileall Cisco_ui Forti_ui_app_bundle unified_ui

------
https://chatgpt.com/codex/tasks/task_e_68d1194e44fc832089f0869f534b4b69

## Sourcery 总结

通过注入 CSS 变量，强制使用白色回退并统一 Cisco、Fortinet 和统一用户界面中的深色模式样式，同时确保标题、占位符和上传组件具有高对比度。

增强功能：
- 引入 `apply_dark_theme` 注入器并包裹 Cisco 页面，以应用一致的深色模式排版和组件样式
- 将 Cisco 和 Fortinet 用户界面中硬编码的侧边栏和导航颜色替换为 CSS 变量和白色文本回退
- 增强 Cisco、Fortinet 和 `unified_ui` 中的占位符、标题和文件上传器文本颜色，以确保在深色模式下有足够的对比度

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce white fallbacks and unify dark mode styling across Cisco, Fortinet, and unified UIs by injecting CSS variables and ensuring high contrast for captions, placeholders, and uploader components.

Enhancements:
- Introduce apply_dark_theme injector and wrap Cisco pages to apply consistent dark mode typography and component styling
- Replace hardcoded sidebar and navigation colors in Cisco and Fortinet UIs with CSS variables and white text fallbacks
- Strengthen placeholder, caption, and file uploader text colors in Cisco, Fortinet, and unified_ui to ensure sufficient contrast in dark mode

</details>