### PR TITLE
Revert "Fix dark mode typography overrides and update theme toggle label"

### DIFF
--- a/Forti_ui_app_bundle/ui_pages/__init__.py
+++ b/Forti_ui_app_bundle/ui_pages/__init__.py
@@ -74,10 +74,7 @@ def apply_dark_theme() -> None:  # [ADDED]
             line-height: 1.65;
         }
         div[data-testid="stAppViewContainer"] .main .block-container h1,
-
-        div[data-testid="stAppViewContainer"] .main .block-container .stMarkdown h1,
-        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stMarkdownContainer"] h1 {
-
+        div[data-testid="stAppViewContainer"] .main .block-container .stMarkdown h1 {
             color: var(--df-title-color) !important;
             font-size: var(--df-font-h1);
             font-weight: 700;
@@ -85,10 +82,7 @@ def apply_dark_theme() -> None:  # [ADDED]
             margin-bottom: 0.75rem;
         }
         div[data-testid="stAppViewContainer"] .main .block-container h2,
-
-        div[data-testid="stAppViewContainer"] .main .block-container .stMarkdown h2,
-        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stMarkdownContainer"] h2 {
-r
+        div[data-testid="stAppViewContainer"] .main .block-container .stMarkdown h2 {
             color: var(--df-heading2-color) !important;
             font-size: var(--df-font-h2);
             font-weight: 600;
@@ -98,10 +92,7 @@ r
         div[data-testid="stAppViewContainer"] .main .block-container h3,
         div[data-testid="stAppViewContainer"] .main .block-container h4,
         div[data-testid="stAppViewContainer"] .main .block-container .stMarkdown h3,
-        div[data-testid="stAppViewContainer"] .main .block-container .stMarkdown h4,
-        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stMarkdownContainer"] h3,
-        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stMarkdownContainer"] h4 {
-
+        div[data-testid="stAppViewContainer"] .main .block-container .stMarkdown h4 {
             color: var(--df-heading3-color) !important;
             font-size: var(--df-font-h3);
             font-weight: 600;
@@ -136,22 +127,6 @@ r
             color: var(--df-label-color) !important;
             font-size: var(--df-font-label);
             font-weight: 500;
-        }
-        div[data-testid="stAppViewContainer"] .main .block-container label span,
-        div[data-testid="stAppViewContainer"] .main .block-container label p {
-            color: var(--df-label-color) !important;
-        }
-        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stMarkdownContainer"] > * {
-            color: var(--df-body-color) !important;
-        }
-        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stSelectbox"] label,
-        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stSelectbox"] label span,
-        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stSelectbox"] label p {
-            color: var(--df-label-color) !important;
-        }
-        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stSelectbox"] div[data-baseweb="select"] *,
-        div[data-testid="stAppViewContainer"] .main .block-container div[data-testid="stSelectbox"] div[data-baseweb="select"] input {
-            color: var(--df-title-color) !important;
         }
         div[data-testid="stAppViewContainer"] .main .block-container small,
         div[data-testid="stAppViewContainer"] .main .block-container .stCaption,


### PR DESCRIPTION
Reverts ch3njay/D_Flare_Merge#23

## Sourcery 总结

通过移除针对标题、标签、Markdown 容器和选择组件新增的 CSS 覆盖规则，恢复之前暗模式排版和主题切换标签的改动。

Bug 修复:
- 移除针对 h1–h4 标题的暗模式排版覆盖的 CSS 规则
- 移除暗色主题下针对标签 span 元素、Markdown 容器正文文本和选择框元素的 CSS 覆盖规则

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Revert the previous dark mode typography and theme toggle label changes by removing the added CSS overrides for headings, labels, markdown containers, and select components.

Bug Fixes:
- Remove CSS rules for dark mode typography overrides on headings h1–h4
- Remove CSS overrides for label spans, markdown container body text, and selectbox elements in dark theme

</details>