### PR TITLE
Add brand-specific hero card theming

### DIFF
--- a/unified_ui/app.py
+++ b/unified_ui/app.py
@@ -1284,14 +1284,20 @@ def _render_brand_highlights(brand: str) -> bool:
         return False
 
     st.markdown('<div class="feature-cards-container">', unsafe_allow_html=True)
-    
+
+    brand_card_class = "feature-card"
+    if brand == "Fortinet":
+        brand_card_class = "feature-card fortinet-card"
+    elif brand == "Cisco":
+        brand_card_class = "feature-card cisco-card"
+
     for row in _chunked(highlights, 3):
         columns = st.columns(len(row))
         for column, (icon, title, desc) in zip(columns, row):
             variant = FEATURE_VARIANTS.get(title, "secondary")
             column.markdown(
                 f"""
-                <div class="feature-card" data-variant="{html.escape(variant)}">
+                <div class="{brand_card_class}" data-variant="{html.escape(variant)}">
                     <div class="feature-card__icon">{html.escape(icon)}</div>
                     <h4 class="feature-card__title">{html.escape(title)}</h4>
                     <p class="feature-card__desc">{html.escape(desc)}</p>

--- a/unified_ui/theme_controller.py
+++ b/unified_ui/theme_controller.py
@@ -84,6 +84,10 @@ def render_theme_switcher() -> None:
     with st.sidebar:
         st.markdown("""
             <style>
+            :root {
+                --fortinet-hero-bg: #cc4d00; /* # [NEW] */
+                --cisco-hero-bg: #0059b3; /* # [NEW] */
+            }
             /* Global Card Styles */
             .feature-card {
                 background: var(--secondaryBackgroundColor);
@@ -132,6 +136,14 @@ def render_theme_switcher() -> None:
                 gap: 1rem;
                 margin: 2rem auto;
                 max-width: 1200px;
+            }
+
+            .feature-card.fortinet-card {
+                background: var(--fortinet-hero-bg); /* # [NEW] */
+            }
+
+            .feature-card.cisco-card {
+                background: var(--cisco-hero-bg); /* # [NEW] */
             }
             </style>
             """, unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
- define brand-specific hero card background tokens in the shared theme switcher CSS
- apply fortinet and cisco feature card classes when rendering brand highlights so cards use the new colors

## Testing
- not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68d7fd7f26b88320911f77e265788cf3