### PR TITLE
Align theme controller feature card and button styling

### DIFF
--- a/unified_ui/theme_controller.py
+++ b/unified_ui/theme_controller.py
@@ -174,6 +174,10 @@ def _apply_theme_styles(theme_config: Dict[str, Any]) -> None:
             color-scheme: {theme_config['base']};
             --theme-font-scale: {font_scale};
             {css_variables}
+            --hover-glow: var(--theme-customTheme-card-hover-shadow);
+            --button-gradient-start: var(--theme-customTheme-primary-gradient-start);
+            --button-gradient-end: var(--theme-customTheme-primary-gradient-end);
+            --button-glow: var(--theme-customTheme-button-shadow);
         }}
 
         html {{
@@ -340,28 +344,34 @@ def _apply_theme_styles(theme_config: Dict[str, Any]) -> None:
         }}
 
         .feature-card:hover {{
-            transform: translateY(-3px);
-            box-shadow: var(--theme-customTheme-card-hover-shadow);
+            transform: translateY(-4px) scale(1.02);
+            box-shadow: var(--hover-glow);
+        }}
+
+        .feature-card__icon {{
+            background: linear-gradient(135deg, var(--primary), var(--primary-hover));
+            color: #ffffff;
+            box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
         }}
 
         .stButton > button {{
             background: linear-gradient(
                 135deg,
-                var(--theme-customTheme-primary-gradient-start),
-                var(--theme-customTheme-primary-gradient-end)
+                var(--button-gradient-start),
+                var(--button-gradient-end)
             ) !important;
             border: 1px solid transparent !important;
             border-radius: 0.75rem !important;
             color: white !important;
             font-weight: 700 !important;
             padding: 0.85rem 1.5rem !important;
-            box-shadow: var(--theme-customTheme-button-shadow) !important;
+            box-shadow: var(--button-glow) !important;
             transition: transform 0.25s ease, box-shadow 0.25s ease;
         }}
 
         .stButton > button:hover {{
             transform: translateY(-2px) !important;
-            box-shadow: var(--theme-customTheme-card-hover-shadow) !important;
+            box-shadow: var(--hover-glow) !important;
         }}
 
         .theme-config-tip {{


### PR DESCRIPTION
## Summary
- map theme-specific custom properties to shared hover glow and button gradient variables in the theme controller
- update feature cards to use the shared hover glow effect and apply the brand gradient to their icons
- switch button styling to the global button gradient and glow variables for consistency with the app implementation

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68da04528b108320b33b3a1dffe56459