### PR TITLE
Update theme switcher icons and styling

### DIFF
--- a/unified_ui/theme_controller.py
+++ b/unified_ui/theme_controller.py
@@ -85,7 +85,7 @@ THEME_CONFIGS: Dict[str, Dict[str, Any]] = {
     THEME_LIGHT: {
         "base": "light",
         "font_scale": _FONT_SCALE,
-        "icon": "🌤️",
+        "icon": '<i class="fa-solid fa-sun"></i>',
         "tagline": "柔和日光",
         "description": "亮色系搭配暖色重點，適合展示報表與簡報場景。",
         "palette": ["#FF6B2C", "#1ABC9C", "#38bdf8"],
@@ -107,7 +107,7 @@ THEME_CONFIGS: Dict[str, Dict[str, Any]] = {
     THEME_DARK: {
         "base": "dark",
         "font_scale": _FONT_SCALE,
-        "icon": "🌙",
+        "icon": '<i class="fa-solid fa-moon"></i>',
         "tagline": "夜幕量測",
         "description": "高對比與霓虹重點，適合控制台與監控儀表板。",
         "palette": ["#1ABC9C", "#6366f1", "#facc15"],
@@ -129,7 +129,7 @@ THEME_CONFIGS: Dict[str, Dict[str, Any]] = {
     THEME_CUSTOM: {
         "base": "dark",
         "font_scale": _FONT_SCALE,
-        "icon": "🎨",
+        "icon": '<i class="fa-solid fa-palette"></i>',
         "tagline": "自訂調色盤",
         "description": "依照 config 設定調整品牌色彩，適合客製化展示。",
         "palette": ["#f97316", "#38bdf8", "#9b59b6"],
@@ -484,6 +484,22 @@ def render_theme_switcher() -> None:
                 horizontal=False,
                 key="theme_switcher",
                 label_visibility="collapsed",
+            )
+
+            st.markdown(
+                """
+                <style>
+                div[data-testid="stSidebar"] div[role="radiogroup"] label span {
+                    display: flex;
+                    align-items: center;
+                    gap: 0.5rem;
+                }
+                div[data-testid="stSidebar"] div[role="radiogroup"] label span i {
+                    font-size: 1rem;
+                }
+                </style>
+                """,
+                unsafe_allow_html=True,
             )
 
             switch_theme(selection)


### PR DESCRIPTION
## Summary
- replace theme switcher emoji icons with Font Awesome equivalents
- inject sidebar radio button CSS so Font Awesome icons render properly alongside text

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da15b0cdb8832082b996d19aaa07cf

## Sourcery 摘要

将主题切换器中的表情符号图标替换为 Font Awesome 等效图标，并注入自定义 CSS 以正确对齐和调整侧边栏单选按钮中的图标大小

增强：
- 将浅色、深色和自定义主题的表情符号图标替换为 Font Awesome `<i>` 元素
- 向侧边栏注入 CSS，以样式化和对齐 Font Awesome 图标，使其与主题标签并排显示

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace emoji icons in the theme switcher with Font Awesome equivalents and inject custom CSS to properly align and size the icons in the sidebar radio buttons

Enhancements:
- Replace light, dark, and custom theme emoji icons with Font Awesome <i> elements
- Inject CSS into sidebar to style and align Font Awesome icons alongside theme labels

</details>