### PR TITLE
Refine highlight cards and sidebar icons

### DIFF
--- a/Cisco_ui/ui_app.py
+++ b/Cisco_ui/ui_app.py
@@ -57,13 +57,6 @@ _RAW_PAGES: Mapping[str, Callable[[], None]] = {
 }
 
 PAGES = {name: _with_theme(page) for name, page in _RAW_PAGES.items()}
-PAGE_EMOJIS = {
-    "通知模組": "🔔",
-    "Log 擷取": "📄",
-    "模型推論": "🔍",
-    "圖表預覽": "📊",
-    "資料清理": "🗑",
-}
 PAGE_ICONS = {
     "通知模組": "bell",
     "Log 擷取": "folder",
@@ -130,7 +123,7 @@ def _render_sidebar() -> str:
     )
 
     page_keys = list(PAGES.keys())
-    page_labels = [f"{PAGE_EMOJIS[name]} {name}" for name in page_keys]
+    page_labels = page_keys
 
     with st.sidebar:
         st.title("Cisco D-FLARE")

--- a/Forti_ui_app_bundle/ui_app.py
+++ b/Forti_ui_app_bundle/ui_app.py
@@ -84,21 +84,12 @@ PAGES = {
 }
 
 PAGE_ICONS = {
-    "Training Pipeline": "cpu",
-    "GPU ETL Pipeline": "gpu",
-    "Model Inference": "search",
+    "Training Pipeline": "gear",
+    "GPU ETL Pipeline": "speedometer2",
+    "Model Inference": "cpu",
     "Folder Monitor": "folder",
     "Visualization": "bar-chart",
     "Notifications": "bell",
-}
-
-PAGE_EMOJIS = {
-    "Training Pipeline": "🛠️",
-    "GPU ETL Pipeline": "🚀",
-    "Model Inference": "🔍",
-    "Folder Monitor": "📁",
-    "Visualization": "📊",
-    "Notifications": "🔔",
 }
 
 PAGE_DESCRIPTIONS = {
@@ -111,7 +102,7 @@ PAGE_DESCRIPTIONS = {
 }
 
 page_keys = list(PAGES.keys())
-page_labels = [f"{PAGE_EMOJIS[k]} {k}" for k in page_keys]
+page_labels = page_keys
 
 with st.sidebar:
     st.title("D-FLARE system")
@@ -126,7 +117,7 @@ with st.sidebar:
         menu_class = "menu-collapsed" if st.session_state.menu_collapse else "menu-expanded"
         with st.container():
             st.markdown(f"<div class='{menu_class}'>", unsafe_allow_html=True)
-            selection_label = option_menu(
+            selection = option_menu(
                 None,
                 page_labels,
                 icons=[PAGE_ICONS[k] for k in page_keys],
@@ -151,20 +142,9 @@ with st.sidebar:
             )
             st.markdown("</div>", unsafe_allow_html=True)
 
-            st.markdown(
-                """
-                <script>
-                const links = window.parent.document.querySelectorAll('.nav-link');
-                links.forEach((el) => el.setAttribute('title', el.textContent));
-                </script>
-                """,
-                unsafe_allow_html=True,
-            )
-
     else:  # Fallback to simple radio when option_menu missing
-        selection_label = st.radio("Go to", page_labels)
+        selection = st.radio("Go to", page_labels)
 
-    selection = page_keys[page_labels.index(selection_label)]
     st.markdown(PAGE_DESCRIPTIONS.get(selection, ""))
 
 PAGES[selection]()

--- a/unified_ui/app.py
+++ b/unified_ui/app.py
@@ -84,7 +84,7 @@ BRAND_HIGHLIGHTS: dict[str, list[Highlight]] = {
     ],
     "Cisco": [
         ("📡", "ASA 日誌擷取", "針對 Cisco ASA 日誌格式優化的擷取與清洗流程。"),
-        ("🤖", "模型推論指引", "依步驟完成資料上傳、模型載入與結果檢視，降低操作門檻。"),
+        ("🧭", "模型推論指引", "依步驟完成資料上傳、模型載入與結果檢視，降低操作門檻。"),
         ("🌐", "跨平台告警", "彈性整合多種通訊渠道，將分析結果分送至各平台。"),
     ],
 }
@@ -111,20 +111,57 @@ def _ensure_session_defaults() -> None:
         <style>
         /* Card Styles */
         .feature-card {
-            background: var(--secondaryBackgroundColor);
-            border: 1px solid rgba(255, 255, 255, 0.1);
-            border-radius: 1rem;
-            padding: 1.5rem;
-            margin: 0.5rem 0;
-            transition: all 0.3s ease;
-            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+            padding: 2.35rem 2.05rem 1.85rem;
+            border-radius: 22px;
+            border: 1px solid var(--card-border);
+            background: var(--card-background);
+            box-shadow: var(--card-shadow);
+            transition: transform 0.25s ease, box-shadow 0.25s ease;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            text-align: center;
+            gap: 1rem;
+            margin-top: 1.5rem;
+            margin-inline: auto;
         }
-        
+
         .feature-card:hover {
-            transform: translateY(-3px);
-            box-shadow: 0 8px 16px -2px rgba(0, 0, 0, 0.2);
+            transform: translateY(-4px) scale(1.02);
+            box-shadow: var(--hover-glow);
         }
-        
+
+        .feature-card__icon {
+            width: 52px;
+            height: 52px;
+            border-radius: 50%;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 1.6rem;
+            margin: 0 auto 1.15rem;
+            background: linear-gradient(135deg, var(--primary), var(--primary-hover));
+            color: #ffffff;
+            box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
+        }
+
+        .feature-card__title {
+            font-size: var(--font-h3);
+            font-weight: 700;
+            color: var(--text-h3) !important;
+            margin-bottom: 0.25rem;
+            text-align: center;
+        }
+
+        .feature-card__desc {
+            color: var(--text-body) !important;
+            margin: 0;
+            font-size: calc(var(--font-body) - 0.3px);
+            line-height: 1.65;
+            text-align: center;
+        }
+
         /* Button Styles */
         .stButton button {
             background-color: var(--primaryColor) !important;
@@ -148,15 +185,6 @@ def _ensure_session_defaults() -> None:
             text-align: center;
         }
         
-        /* Feature Cards Container */
-        .feature-cards-container {
-            display: flex;
-            justify-content: center;
-            flex-wrap: wrap;
-            gap: 1rem;
-            margin: 2rem auto;
-            max-width: 1200px;
-        }
         </style>
     """, unsafe_allow_html=True)
 
@@ -918,21 +946,13 @@ def _render_brand_highlights(brand: str) -> bool:
     if not highlights:
         return False
 
-    st.markdown('<div class="feature-cards-container">', unsafe_allow_html=True)
-
-    brand_card_class = "feature-card"
-    if brand == "Fortinet":
-        brand_card_class = "feature-card fortinet-card"
-    elif brand == "Cisco":
-        brand_card_class = "feature-card cisco-card"
-
     for row in _chunked(highlights, 3):
         columns = st.columns(len(row))
         for column, (icon, title, desc) in zip(columns, row):
             variant = FEATURE_VARIANTS.get(title, "secondary")
             column.markdown(
                 f"""
-                <div class="{brand_card_class}" data-variant="{html.escape(variant)}">
+                <div class="feature-card" data-variant="{html.escape(variant)}">
                     <div class="feature-card__icon">{html.escape(icon)}</div>
                     <h4 class="feature-card__title">{html.escape(title)}</h4>
                     <p class="feature-card__desc">{html.escape(desc)}</p>
@@ -940,8 +960,6 @@ def _render_brand_highlights(brand: str) -> bool:
                 """,
                 unsafe_allow_html=True,
             )
-    
-    st.markdown('</div>', unsafe_allow_html=True)
     return True
 
 


### PR DESCRIPTION
## Summary
- restyle the hero highlight cards to match the palette reference design and update the Cisco guidance icon
- align the Fortinet and Cisco sidebar menus to rely purely on Bootstrap icons without emojis to avoid missing glyphs

## Testing
- python -m compileall unified_ui/app.py Forti_ui_app_bundle/ui_app.py Cisco_ui/ui_app.py

------
https://chatgpt.com/codex/tasks/task_e_68da1b89a618832098a8978e21f5402b

## Sourcery 总结

重构英雄高亮卡片样式以匹配参考调色板并简化其标记，更新 Cisco 指导卡片图标，并通过删除表情符号和调整图标映射来标准化侧边栏菜单以仅使用 Bootstrap 图标。

改进点:
- 全面改进功能卡片样式：更新了 CSS 变量、布局和类以符合设计系统
- 将 Cisco 模型推理指导卡片图标从机器人表情符号替换为指南针表情符号
- 简化功能卡片标记，通过删除品牌特定容器并统一卡片类使用
- 从 Fortinet 和 Cisco 侧边栏中删除表情符号，更新页面图标映射，并调整菜单组件的选择逻辑

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restyle hero highlight cards to match the reference palette and simplify their markup, update the Cisco guidance card icon, and standardize sidebar menus to use Bootstrap icons only by removing emojis and adjusting icon mappings

Enhancements:
- Overhaul feature card styling: updated CSS variables, layout, and classes to align with the design system
- Replace Cisco model inference guidance card icon from a robot emoji to a compass emoji
- Simplify feature card markup by removing brand-specific containers and unifying card class usage
- Remove emojis from Fortinet and Cisco sidebars, update page icon mappings, and adjust selection logic for menu components

</details>