### PR TITLE
Refresh UI gradients and correct upload guidance

### DIFF
--- a/Cisco_ui/ui_pages/log_monitor.py
+++ b/Cisco_ui/ui_pages/log_monitor.py
@@ -472,7 +472,7 @@ def render_directory_selector(
             accept_multiple_files=True,
             type=["csv", "txt", "log", *ARCHIVE_TYPES],
             help=help_text
-            or "透過瀏覽按鈕挑選資料夾中的檔案，系統會建立可監控的目錄 (支援壓縮檔，單檔 200GB 以內)。",
+            or "透過瀏覽按鈕挑選資料夾中的檔案，系統會建立可監控的目錄 (支援壓縮檔，單檔 2GB 以內)。",
         )
 
     if uploaded_files:
@@ -542,7 +542,7 @@ def app() -> None:
             "選擇二元模型檔 (.pkl/.joblib)",
             type=["pkl", "joblib", *ARCHIVE_TYPES],
             key="cisco_binary_model_upload",
-            help="透過瀏覽按鈕挑選二元分類模型，將自動儲存並套用於監控流程。支援壓縮檔，上限 200GB。",
+            help="透過瀏覽按鈕挑選二元分類模型，將自動儲存並套用於監控流程。支援壓縮檔，上限 2GB。",
         )
         _render_path_preview("目前使用的二元模型", current_binary, icon="🧠")
 
@@ -553,7 +553,7 @@ def app() -> None:
             "選擇多元模型檔 (.pkl/.joblib)",
             type=["pkl", "joblib", *ARCHIVE_TYPES],
             key="cisco_multi_model_upload",
-            help="透過瀏覽按鈕挑選多元分類模型，將自動儲存並套用於監控流程。支援壓縮檔，上限 200GB。",
+            help="透過瀏覽按鈕挑選多元分類模型，將自動儲存並套用於監控流程。支援壓縮檔，上限 2GB。",
         )
         _render_path_preview("目前使用的多元模型", current_multi, icon="🗂️")
 
@@ -590,7 +590,7 @@ def app() -> None:
         "選擇要分析的 log 檔案",
         type=["log", "txt", "csv", *ARCHIVE_TYPES],
         accept_multiple_files=False,
-        help="透過瀏覽按鈕挑選 ASA log，系統會自動儲存並帶入分析流程。支援壓縮檔，上限 200GB。",
+        help="透過瀏覽按鈕挑選 ASA log，系統會自動儲存並帶入分析流程。支援壓縮檔，上限 2GB。",
         key="cisco_manual_file_uploader",
     )
     if uploaded_manual is not None:

--- a/Cisco_ui/ui_pages/model_inference.py
+++ b/Cisco_ui/ui_pages/model_inference.py
@@ -78,7 +78,7 @@ def app() -> None:
         "上傳原始 log (CSV/TXT/壓縮檔)",
         type=["csv", "txt", "log", *ARCHIVE_TYPES],
         key="cisco_inference_log_uploader",
-        help="Max file size: 200GB。支援 CSV/TXT/LOG 與常見壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
+        help="Max file size: 2GB。支援 CSV/TXT/LOG 與常見壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
     )
     can_use_recent = bool(saved_log)
     use_recent_log = st.checkbox(
@@ -106,7 +106,7 @@ def app() -> None:
         "上傳二元模型 (.pkl/.joblib)",
         type=["pkl", "joblib", *ARCHIVE_TYPES],
         key="binary_upload",
-        help="Max file size: 200GB. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
+        help="Max file size: 2GB. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
     )
     if upload_binary is not None:
         _render_path_preview("上傳的二元模型", upload_binary.name, icon="🧠")
@@ -119,7 +119,7 @@ def app() -> None:
         "上傳多元模型 (.pkl/.joblib)",
         type=["pkl", "joblib", *ARCHIVE_TYPES],
         key="multi_upload",
-        help="Max file size: 200GB. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
+        help="Max file size: 2GB. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
     )
     if upload_multi is not None:
         _render_path_preview("上傳的多元模型", upload_multi.name, icon="🗂️")

--- a/Forti_ui_app_bundle/ui_pages/folder_monitor_ui.py
+++ b/Forti_ui_app_bundle/ui_pages/folder_monitor_ui.py
@@ -361,7 +361,7 @@ def app() -> None:
         "Upload logs or archives to the monitored folder",
         type=["csv", "txt", "log", *ARCHIVE_TYPES],
         accept_multiple_files=True,
-        help="Max file size: 200GB。支援 CSV/TXT/LOG 與常見壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
+        help="Max file size: 2GB。支援 CSV/TXT/LOG 與常見壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
         key="folder_monitor_upload",
     )
 
@@ -391,7 +391,7 @@ def app() -> None:
     bin_upload = st.file_uploader(
         "Upload binary model",
         type=["pkl", "joblib", *ARCHIVE_TYPES],
-        help="Max file size: 200GB. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
+        help="Max file size: 2GB. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
         key="binary_model_upload",
     )
     if bin_upload is not None:
@@ -403,7 +403,7 @@ def app() -> None:
     mul_upload = st.file_uploader(
         "Upload multiclass model",
         type=["pkl", "joblib", *ARCHIVE_TYPES],
-        help="Max file size: 200GB. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
+        help="Max file size: 2GB. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
         key="multi_model_upload",
     )
     if mul_upload is not None:

--- a/Forti_ui_app_bundle/ui_pages/gpu_etl_ui.py
+++ b/Forti_ui_app_bundle/ui_pages/gpu_etl_ui.py
@@ -13,7 +13,7 @@ def app() -> None:
         "Upload log files",
         type=["csv", "txt", "log", *ARCHIVE_TYPES],
         accept_multiple_files=True,
-        help="Max file size: 200GB per file。支援 CSV/TXT/LOG 與壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
+        help="Max file size: 2GB per file。支援 CSV/TXT/LOG 與壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
     )
     do_clean = st.checkbox("Run cleaning", value=True)
     do_map = st.checkbox("Run mapping", value=True)

--- a/Forti_ui_app_bundle/ui_pages/inference_ui.py
+++ b/Forti_ui_app_bundle/ui_pages/inference_ui.py
@@ -42,17 +42,17 @@ def app() -> None:
     data_file = st.file_uploader(
         "Upload data CSV",
         type=["csv", *ARCHIVE_TYPES],
-        help="Max file size: 200GB. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
+        help="Max file size: 2GB. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
     )
     binary_model = st.file_uploader(
         "Upload binary model",
         type=["pkl", "joblib", *ARCHIVE_TYPES],
-        help="Max file size: 200GB. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
+        help="Max file size: 2GB. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
     )
     multi_model = st.file_uploader(
         "Upload multiclass model",
         type=["pkl", "joblib", *ARCHIVE_TYPES],
-        help="Max file size: 200GB. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
+        help="Max file size: 2GB. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
     )
     col1, col2 = st.columns(2)
     run_binary = col1.button("Run binary inference")

--- a/Forti_ui_app_bundle/ui_pages/notifier_app.py
+++ b/Forti_ui_app_bundle/ui_pages/notifier_app.py
@@ -93,7 +93,7 @@ def app() -> None:
     uploaded = st.file_uploader(
         "Select result CSV",
         type=["csv", *ARCHIVE_TYPES],
-        help="Max file size: 200GB. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
+        help="Max file size: 2GB. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
     )
     if uploaded is not None:
         temp_dir = tempfile.gettempdir()

--- a/Forti_ui_app_bundle/ui_pages/training_ui.py
+++ b/Forti_ui_app_bundle/ui_pages/training_ui.py
@@ -49,7 +49,7 @@ def app() -> None:
     uploaded_file = st.file_uploader(
         "Upload training CSV",
         type=["csv", *ARCHIVE_TYPES],
-        help="Max file size: 200GB. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
+        help="Max file size: 2GB. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
     )
     task_type = st.selectbox("Task type", ["binary", "multiclass"])
 

--- a/Forti_ui_app_bundle/ui_pages/visualization_ui.py
+++ b/Forti_ui_app_bundle/ui_pages/visualization_ui.py
@@ -74,7 +74,7 @@ def app() -> None:
         uploaded = st.file_uploader(
             "Upload prediction CSV",
             type=["csv", *ARCHIVE_TYPES],
-            help="Max file size: 200GB. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
+            help="Max file size: 2GB. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
         )
         if uploaded is not None:
             df = pd.read_csv(uploaded)

--- a/unified_ui/app.py
+++ b/unified_ui/app.py
@@ -172,17 +172,18 @@ def _ensure_session_defaults() -> None:
 
         /* Button Styles */
         .stButton button {
-            background-color: var(--primaryColor) !important;
-            border: 1px solid transparent !important;
+            background: linear-gradient(135deg, var(--primary-color), var(--secondary-color)) !important;
+            border: none !important;
             border-radius: 0.5rem !important;
-            color: white !important;
+            color: #fff !important;
             font-weight: 600 !important;
-            transition: all 0.3s ease !important;
+            padding: 0.4rem 1rem !important;
+            transition: all 0.3s ease-in-out !important;
+            box-shadow: 0 16px 32px -20px color-mix(in srgb, var(--primary-color) 55%, transparent);
         }
-        
+
         .stButton button:hover {
-            opacity: 0.9;
-            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+            box-shadow: 0 0 10px color-mix(in srgb, var(--primary-color) 60%, transparent);
             transform: translateY(-1px);
         }
         
@@ -249,6 +250,8 @@ def _inject_theme_styles() -> None:
             --secondary-start: color-mix(in srgb, var(--primaryColor) 68%, var(--textColor) 32%);
             --secondary-end: color-mix(in srgb, var(--primaryColor) 48%, var(--backgroundColor) 52%);
             --secondary-hover: color-mix(in srgb, var(--primaryColor) 62%, var(--textColor) 38%);
+            --primary-color: var(--primary);
+            --secondary-color: var(--secondary-start);
             --warning: color-mix(in srgb, var(--primaryColor) 40%, var(--textColor) 60%);
             --warning-emphasis: color-mix(in srgb, var(--primaryColor) 55%, var(--textColor) 45%);
             --alert-icon-bg: color-mix(in srgb, var(--primaryColor) 20%, transparent);
@@ -557,11 +560,11 @@ def _inject_theme_styles() -> None:
         .stButton > button,
         .stDownloadButton > button,
         .stFormSubmitButton > button {
-            background: linear-gradient(135deg, var(--primary), var(--primary-hover));
-            color: var(--text-on-primary);
+            background: linear-gradient(135deg, var(--primary-color), var(--secondary-color));
+            color: #fff;
             border: none;
-            border-radius: 14px;
-            padding: 0.75rem 1.45rem;
+            border-radius: 0.5rem;
+            padding: 0.4rem 1rem;
             font-weight: 600;
             font-size: var(--font-label);
             display: inline-flex;
@@ -569,15 +572,15 @@ def _inject_theme_styles() -> None:
             justify-content: center;
             gap: 0.45rem;
             letter-spacing: 0.01em;
-            box-shadow: var(--hover-glow);
+            box-shadow: 0 18px 36px -22px color-mix(in srgb, var(--primary-color) 55%, transparent);
             margin: 0.2rem 0.35rem 0.2rem 0;
         }
 
         .stButton > button:hover,
         .stDownloadButton > button:hover,
         .stFormSubmitButton > button:hover {
-            transform: translateY(-1px) scale(1.02);
-            box-shadow: 0 26px 48px -24px var(--primary-shadow);
+            transform: translateY(-1px);
+            box-shadow: 0 0 10px color-mix(in srgb, var(--primary-color) 60%, transparent);
         }
 
         .stButton > button:focus-visible,

--- a/unified_ui/theme_controller.py
+++ b/unified_ui/theme_controller.py
@@ -96,6 +96,8 @@ THEME_CONFIGS: Dict[str, Dict[str, Any]] = {
             "card-background": "#ffffff",
             "card-border": "#d9e2f1",
             "card-hover-shadow": "0 28px 60px -32px rgba(255, 107, 44, 0.35)",
+            "primary-color": "#FF6B2C",
+            "secondary-color": "#FF834D",
             "primary-gradient-start": "#FF6B2C",
             "primary-gradient-end": "#FF834D",
             "button-shadow": "0 18px 36px -20px rgba(255, 107, 44, 0.46)",
@@ -118,6 +120,8 @@ THEME_CONFIGS: Dict[str, Dict[str, Any]] = {
             "card-background": "rgba(9, 16, 32, 0.88)",
             "card-border": "rgba(120, 144, 180, 0.34)",
             "card-hover-shadow": "0 36px 72px -42px rgba(5, 10, 22, 0.92)",
+            "primary-color": "#1ABC9C",
+            "secondary-color": "#6366f1",
             "primary-gradient-start": "#1ABC9C",
             "primary-gradient-end": "#6366f1",
             "button-shadow": "0 20px 44px -28px rgba(99, 102, 241, 0.55)",
@@ -140,6 +144,8 @@ THEME_CONFIGS: Dict[str, Dict[str, Any]] = {
             "card-background": "rgba(10, 18, 40, 0.88)",
             "card-border": "rgba(120, 144, 180, 0.28)",
             "card-hover-shadow": "0 28px 64px -38px rgba(59, 130, 246, 0.48)",
+            "primary-color": "#38bdf8",
+            "secondary-color": "#9b59b6",
             "primary-gradient-start": "#38bdf8",
             "primary-gradient-end": "#9b59b6",
             "button-shadow": "0 20px 48px -30px rgba(59, 130, 246, 0.65)",
@@ -202,6 +208,15 @@ def _apply_theme_styles(theme_config: Dict[str, Any]) -> None:
         section[data-testid="stSidebar"] {{
             background: var(--theme-customTheme-sidebar-background);
             color: var(--theme-customTheme-sidebar-text);
+        }}
+
+        /* Sidebar 功能目錄 icon 強制顯示 */
+        section[data-testid="stSidebar"] svg,
+        section[data-testid="stSidebar"] i {{
+            display: inline-block !important;
+            opacity: 1 !important;
+            visibility: visible !important;
+            margin-right: 0.5rem;
         }}
 
         section[data-testid="stSidebar"] p,
@@ -355,21 +370,34 @@ def _apply_theme_styles(theme_config: Dict[str, Any]) -> None:
         .stButton > button {{
             background: linear-gradient(
                 135deg,
-                var(--theme-customTheme-primary-gradient-start),
-                var(--theme-customTheme-primary-gradient-end)
+                var(--primary-color),
+                var(--secondary-color)
             ) !important;
-            border: 1px solid transparent !important;
-            border-radius: 0.75rem !important;
-            color: white !important;
-            font-weight: 700 !important;
-            padding: 0.85rem 1.5rem !important;
-            box-shadow: var(--theme-customTheme-button-shadow) !important;
-            transition: transform 0.25s ease, box-shadow 0.25s ease;
+            color: #fff !important;
+            border: none !important;
+            border-radius: 0.5rem !important;
+            padding: 0.4rem 1rem !important;
+            font-weight: 600 !important;
+            box-shadow: var(
+                --theme-customTheme-button-shadow,
+                0 18px 36px -22px color-mix(in srgb, var(--primary-color) 55%, transparent)
+            ) !important;
+            transition: all 0.3s ease-in-out !important;
         }}
 
         .stButton > button:hover {{
-            transform: translateY(-2px) !important;
-            box-shadow: var(--theme-customTheme-card-hover-shadow) !important;
+            box-shadow: 0 0 10px color-mix(in srgb, var(--primary-color) 60%, transparent) !important;
+            transform: translateY(-1px) !important;
+        }}
+
+        /* Align Fortinet "Use current" button with input */
+        div[data-testid="stHorizontalBlock"]:has(input[aria-label="Folder to monitor"]) > div[data-testid="column"]:last-child {{
+            display: flex;
+            align-items: flex-end;
+        }}
+
+        div[data-testid="stHorizontalBlock"]:has(input[aria-label="Folder to monitor"]) > div[data-testid="column"]:last-child .stButton > button {{
+            width: 100%;
         }}
 
         .theme-config-tip {{


### PR DESCRIPTION
## Summary
- define per-theme primary and secondary gradient colors, keep sidebar icons visible, and align the Fortinet "Use current" shortcut
- refresh global button styling with gradient backgrounds and hover glow to improve affordance across brands
- update Cisco and Fortinet upload helpers to reflect the 2GB backend limit and match the existing configuration

## Testing
- not run (UI updates only)


------
https://chatgpt.com/codex/tasks/task_e_68da386ec5d48320a79bf452435b00b6

## Sourcery 总结

刷新 UI 主题，通过引入单独的主/次渐变色、更新按钮样式和布局，并修复 Cisco 和 Fortinet 组件的上传指导限制

Bug 修复:
- 更新 Cisco 和 Fortinet 上传助手，以正确反映后端 2 GB 的文件大小限制

功能改进:
- 定义每个主题的主/次渐变色，以实现一致的主题风格
- 刷新全局按钮样式，更新了渐变色、内边距、边框圆角和悬停发光效果
- 确保侧边栏图标保持可见，并对齐 Fortinet 的“使用当前”快捷按钮

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refresh the UI theming by introducing separate primary/secondary gradient colors, updating button styles and layouts, and fix upload guidance limits across Cisco and Fortinet components

Bug Fixes:
- Update Cisco and Fortinet upload helpers to correctly reflect the 2 GB backend file size limit

Enhancements:
- Define per-theme primary and secondary gradient colors for consistent theming
- Refresh global button styling with updated gradients, padding, border radius, and hover glow
- Ensure sidebar icons remain visible and align the Fortinet "Use current" shortcut button

</details>