### PR TITLE
Standardize upload messaging and gradient styles

### DIFF
--- a/Cisco_ui/ui_pages/log_monitor.py
+++ b/Cisco_ui/ui_pages/log_monitor.py
@@ -20,7 +20,13 @@ from typing import Dict, List, Optional, Set, Tuple
 import pandas as pd
 import streamlit as st
 
+from ui_shared.upload_limits import insert_upload_limit
+
 ARCHIVE_TYPES = ["zip", "tar", "gz", "bz2", "xz", "7z"]
+
+DEFAULT_BROWSE_HELP = insert_upload_limit(
+    "透過瀏覽按鈕挑選資料夾中的檔案，系統會建立可監控的目錄 (支援壓縮檔，單檔 {limit} 以內)。"
+)
 
 try:  # Prefer package-relative imports when available
     from ..training_pipeline.config import PipelineConfig
@@ -471,8 +477,7 @@ def render_directory_selector(
             label_visibility="collapsed",
             accept_multiple_files=True,
             type=["csv", "txt", "log", *ARCHIVE_TYPES],
-            help=help_text
-            or "透過瀏覽按鈕挑選資料夾中的檔案，系統會建立可監控的目錄 (支援壓縮檔，單檔 200GB 以內)。",
+            help=help_text or DEFAULT_BROWSE_HELP,
         )
 
     if uploaded_files:
@@ -542,7 +547,9 @@ def app() -> None:
             "選擇二元模型檔 (.pkl/.joblib)",
             type=["pkl", "joblib", *ARCHIVE_TYPES],
             key="cisco_binary_model_upload",
-            help="透過瀏覽按鈕挑選二元分類模型，將自動儲存並套用於監控流程。支援壓縮檔，上限 200GB。",
+            help=insert_upload_limit(
+                "透過瀏覽按鈕挑選二元分類模型，將自動儲存並套用於監控流程。支援壓縮檔，上限 {limit}。"
+            ),
         )
         _render_path_preview("目前使用的二元模型", current_binary, icon="🧠")
 
@@ -553,7 +560,9 @@ def app() -> None:
             "選擇多元模型檔 (.pkl/.joblib)",
             type=["pkl", "joblib", *ARCHIVE_TYPES],
             key="cisco_multi_model_upload",
-            help="透過瀏覽按鈕挑選多元分類模型，將自動儲存並套用於監控流程。支援壓縮檔，上限 200GB。",
+            help=insert_upload_limit(
+                "透過瀏覽按鈕挑選多元分類模型，將自動儲存並套用於監控流程。支援壓縮檔，上限 {limit}。"
+            ),
         )
         _render_path_preview("目前使用的多元模型", current_multi, icon="🗂️")
 
@@ -590,7 +599,9 @@ def app() -> None:
         "選擇要分析的 log 檔案",
         type=["log", "txt", "csv", *ARCHIVE_TYPES],
         accept_multiple_files=False,
-        help="透過瀏覽按鈕挑選 ASA log，系統會自動儲存並帶入分析流程。支援壓縮檔，上限 200GB。",
+        help=insert_upload_limit(
+            "透過瀏覽按鈕挑選 ASA log，系統會自動儲存並帶入分析流程。支援壓縮檔，上限 {limit}。"
+        ),
         key="cisco_manual_file_uploader",
     )
     if uploaded_manual is not None:

--- a/Cisco_ui/ui_pages/model_inference.py
+++ b/Cisco_ui/ui_pages/model_inference.py
@@ -9,6 +9,8 @@ from typing import Optional
 import pandas as pd
 import streamlit as st
 
+from ui_shared.upload_limits import insert_upload_limit
+
 from .log_monitor import get_log_monitor
 
 ARCHIVE_TYPES = ["zip", "tar", "gz", "bz2", "xz", "7z"]
@@ -78,7 +80,9 @@ def app() -> None:
         "上傳原始 log (CSV/TXT/壓縮檔)",
         type=["csv", "txt", "log", *ARCHIVE_TYPES],
         key="cisco_inference_log_uploader",
-        help="Max file size: 200GB。支援 CSV/TXT/LOG 與常見壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
+        help=insert_upload_limit(
+            "Max file size: {limit}。支援 CSV/TXT/LOG 與常見壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。"
+        ),
     )
     can_use_recent = bool(saved_log)
     use_recent_log = st.checkbox(
@@ -106,7 +110,7 @@ def app() -> None:
         "上傳二元模型 (.pkl/.joblib)",
         type=["pkl", "joblib", *ARCHIVE_TYPES],
         key="binary_upload",
-        help="Max file size: 200GB. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
+        help=insert_upload_limit("Max file size: {limit}. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。"),
     )
     if upload_binary is not None:
         _render_path_preview("上傳的二元模型", upload_binary.name, icon="🧠")
@@ -119,7 +123,7 @@ def app() -> None:
         "上傳多元模型 (.pkl/.joblib)",
         type=["pkl", "joblib", *ARCHIVE_TYPES],
         key="multi_upload",
-        help="Max file size: 200GB. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
+        help=insert_upload_limit("Max file size: {limit}. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。"),
     )
     if upload_multi is not None:
         _render_path_preview("上傳的多元模型", upload_multi.name, icon="🗂️")

--- a/Forti_ui_app_bundle/ui_pages/folder_monitor_ui.py
+++ b/Forti_ui_app_bundle/ui_pages/folder_monitor_ui.py
@@ -8,6 +8,9 @@ from pathlib import Path
 import pandas as pd
 import joblib
 import streamlit as st
+
+from ui_shared.upload_limits import insert_upload_limit
+
 from . import apply_dark_theme  # [ADDED]
 
 ARCHIVE_TYPES = ["zip", "tar", "gz", "bz2", "xz", "7z"]
@@ -321,11 +324,16 @@ def app() -> None:
         _rerun()
 
     with col2:
+        st.markdown(
+            '<div class="fortinet-folder-monitor-block">',
+            unsafe_allow_html=True,
+        )
         st.button(  # [MODIFIED]
             "Use current",
             on_click=_use_cwd,
             help="Set the monitored folder to the current working directory.",  # [ADDED]
         )
+        st.markdown("</div>", unsafe_allow_html=True)
 
     folder_candidate = st.session_state.folder_input.strip()  # [ADDED]
     if folder_candidate:
@@ -361,7 +369,9 @@ def app() -> None:
         "Upload logs or archives to the monitored folder",
         type=["csv", "txt", "log", *ARCHIVE_TYPES],
         accept_multiple_files=True,
-        help="Max file size: 200GB。支援 CSV/TXT/LOG 與常見壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
+        help=insert_upload_limit(
+            "Max file size: {limit}。支援 CSV/TXT/LOG 與常見壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。"
+        ),
         key="folder_monitor_upload",
     )
 
@@ -391,7 +401,7 @@ def app() -> None:
     bin_upload = st.file_uploader(
         "Upload binary model",
         type=["pkl", "joblib", *ARCHIVE_TYPES],
-        help="Max file size: 200GB. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
+        help=insert_upload_limit("Max file size: {limit}. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。"),
         key="binary_model_upload",
     )
     if bin_upload is not None:
@@ -403,7 +413,7 @@ def app() -> None:
     mul_upload = st.file_uploader(
         "Upload multiclass model",
         type=["pkl", "joblib", *ARCHIVE_TYPES],
-        help="Max file size: 200GB. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
+        help=insert_upload_limit("Max file size: {limit}. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。"),
         key="multi_model_upload",
     )
     if mul_upload is not None:

--- a/Forti_ui_app_bundle/ui_pages/gpu_etl_ui.py
+++ b/Forti_ui_app_bundle/ui_pages/gpu_etl_ui.py
@@ -1,6 +1,9 @@
 import streamlit as st
 import threading
 import time
+
+from ui_shared.upload_limits import insert_upload_limit
+
 from ..gpu_etl_pipeliner import run_pipeline
 from . import apply_dark_theme  # [ADDED]
 
@@ -13,7 +16,9 @@ def app() -> None:
         "Upload log files",
         type=["csv", "txt", "log", *ARCHIVE_TYPES],
         accept_multiple_files=True,
-        help="Max file size: 200GB per file。支援 CSV/TXT/LOG 與壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
+        help=insert_upload_limit(
+            "Max file size: {limit} per file。支援 CSV/TXT/LOG 與壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。"
+        ),
     )
     do_clean = st.checkbox("Run cleaning", value=True)
     do_map = st.checkbox("Run mapping", value=True)

--- a/Forti_ui_app_bundle/ui_pages/inference_ui.py
+++ b/Forti_ui_app_bundle/ui_pages/inference_ui.py
@@ -1,7 +1,11 @@
 import io
 import threading
 import time
+
 import streamlit as st
+
+from ui_shared.upload_limits import insert_upload_limit
+
 from . import _ensure_module, apply_dark_theme  # [MODIFIED]
 
 ARCHIVE_TYPES = ["zip", "tar", "gz", "bz2", "xz", "7z"]
@@ -42,17 +46,17 @@ def app() -> None:
     data_file = st.file_uploader(
         "Upload data CSV",
         type=["csv", *ARCHIVE_TYPES],
-        help="Max file size: 200GB. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
+        help=insert_upload_limit("Max file size: {limit}. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。"),
     )
     binary_model = st.file_uploader(
         "Upload binary model",
         type=["pkl", "joblib", *ARCHIVE_TYPES],
-        help="Max file size: 200GB. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
+        help=insert_upload_limit("Max file size: {limit}. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。"),
     )
     multi_model = st.file_uploader(
         "Upload multiclass model",
         type=["pkl", "joblib", *ARCHIVE_TYPES],
-        help="Max file size: 200GB. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
+        help=insert_upload_limit("Max file size: {limit}. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。"),
     )
     col1, col2 = st.columns(2)
     run_binary = col1.button("Run binary inference")

--- a/Forti_ui_app_bundle/ui_pages/notifier_app.py
+++ b/Forti_ui_app_bundle/ui_pages/notifier_app.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 import streamlit as st
 
+from ui_shared.upload_limits import insert_upload_limit
+
 from ..notifier import notify_from_csv, send_discord, send_line_to_all
 from . import apply_dark_theme  # [ADDED]
 
@@ -93,7 +95,7 @@ def app() -> None:
     uploaded = st.file_uploader(
         "Select result CSV",
         type=["csv", *ARCHIVE_TYPES],
-        help="Max file size: 200GB. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
+        help=insert_upload_limit("Max file size: {limit}. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。"),
     )
     if uploaded is not None:
         temp_dir = tempfile.gettempdir()

--- a/Forti_ui_app_bundle/ui_pages/training_ui.py
+++ b/Forti_ui_app_bundle/ui_pages/training_ui.py
@@ -5,6 +5,9 @@ import os
 import io
 import contextlib
 import queue
+
+from ui_shared.upload_limits import insert_upload_limit
+
 from . import _ensure_module, apply_dark_theme  # [MODIFIED]
 
 ARCHIVE_TYPES = ["zip", "tar", "gz", "bz2", "xz", "7z"]
@@ -49,7 +52,7 @@ def app() -> None:
     uploaded_file = st.file_uploader(
         "Upload training CSV",
         type=["csv", *ARCHIVE_TYPES],
-        help="Max file size: 200GB. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
+        help=insert_upload_limit("Max file size: {limit}. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。"),
     )
     task_type = st.selectbox("Task type", ["binary", "multiclass"])
 

--- a/Forti_ui_app_bundle/ui_pages/visualization_ui.py
+++ b/Forti_ui_app_bundle/ui_pages/visualization_ui.py
@@ -1,6 +1,9 @@
 import html
 
 import streamlit as st
+
+from ui_shared.upload_limits import insert_upload_limit
+
 from . import _ensure_module, apply_dark_theme  # [MODIFIED]
 _ensure_module("numpy", "numpy_stub")
 _ensure_module("pandas", "pandas_stub")
@@ -74,7 +77,7 @@ def app() -> None:
         uploaded = st.file_uploader(
             "Upload prediction CSV",
             type=["csv", *ARCHIVE_TYPES],
-            help="Max file size: 200GB. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。",
+            help=insert_upload_limit("Max file size: {limit}. 支援壓縮檔 (ZIP/TAR/GZ/BZ2/XZ/7Z)。"),
         )
         if uploaded is not None:
             df = pd.read_csv(uploaded)

--- a/ui_shared/__init__.py
+++ b/ui_shared/__init__.py
@@ -1,0 +1,11 @@
+"""Shared UI constants and helpers used across brand-specific dashboards."""
+
+from .upload_limits import (
+    UPLOAD_LIMIT_BYTES,
+    UPLOAD_LIMIT_LABEL,
+)
+
+__all__ = [
+    "UPLOAD_LIMIT_BYTES",
+    "UPLOAD_LIMIT_LABEL",
+]

--- a/ui_shared/upload_limits.py
+++ b/ui_shared/upload_limits.py
@@ -1,0 +1,26 @@
+"""Utilities for presenting consistent upload size guidance across apps."""
+
+from __future__ import annotations
+
+# Streamlit's ``maxUploadSize`` configuration is set to 2 GiB (2048 MB).
+# Expose both the raw byte size and a display-friendly label so help copy can be
+# updated from a single location whenever the backend limit changes.
+UPLOAD_LIMIT_BYTES: int = 2 * 1024 * 1024 * 1024
+UPLOAD_LIMIT_LABEL: str = "2GB"
+
+
+def insert_upload_limit(text: str) -> str:
+    """Embed the shared upload limit label into the provided template string.
+
+    The template should contain a ``{limit}`` placeholder. This helper keeps the
+    formatting logic in one place to avoid mismatched messages across the UI.
+    """
+
+    return text.format(limit=UPLOAD_LIMIT_LABEL)
+
+
+__all__ = [
+    "UPLOAD_LIMIT_BYTES",
+    "UPLOAD_LIMIT_LABEL",
+    "insert_upload_limit",
+]

--- a/unified_ui/app.py
+++ b/unified_ui/app.py
@@ -172,17 +172,18 @@ def _ensure_session_defaults() -> None:
 
         /* Button Styles */
         .stButton button {
-            background-color: var(--primaryColor) !important;
-            border: 1px solid transparent !important;
+            background: linear-gradient(135deg, var(--primary-color), var(--secondary-color)) !important;
+            border: none !important;
             border-radius: 0.5rem !important;
-            color: white !important;
+            color: #fff !important;
             font-weight: 600 !important;
-            transition: all 0.3s ease !important;
+            padding: 0.4rem 1rem !important;
+            transition: all 0.3s ease-in-out !important;
+            box-shadow: 0 16px 32px -20px color-mix(in srgb, var(--primary-color) 55%, transparent);
         }
-        
+
         .stButton button:hover {
-            opacity: 0.9;
-            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+            box-shadow: 0 0 10px color-mix(in srgb, var(--primary-color) 60%, transparent);
             transform: translateY(-1px);
         }
         
@@ -249,6 +250,15 @@ def _inject_theme_styles() -> None:
             --secondary-start: color-mix(in srgb, var(--primaryColor) 68%, var(--textColor) 32%);
             --secondary-end: color-mix(in srgb, var(--primaryColor) 48%, var(--backgroundColor) 52%);
             --secondary-hover: color-mix(in srgb, var(--primaryColor) 62%, var(--textColor) 38%);
+            /*
+             * Color variable mapping standardization:
+             * --primary-color is a semantic alias for the active brand hue (--primary).
+             * --secondary-color mirrors --secondary-start to anchor gradient blends.
+             * Centralizing these aliases keeps the gradient button styles consistent
+             * across brand themes and matches the names used in theme_controller.py.
+             */
+            --primary-color: var(--primary);
+            --secondary-color: var(--secondary-start);
             --warning: color-mix(in srgb, var(--primaryColor) 40%, var(--textColor) 60%);
             --warning-emphasis: color-mix(in srgb, var(--primaryColor) 55%, var(--textColor) 45%);
             --alert-icon-bg: color-mix(in srgb, var(--primaryColor) 20%, transparent);
@@ -557,11 +567,11 @@ def _inject_theme_styles() -> None:
         .stButton > button,
         .stDownloadButton > button,
         .stFormSubmitButton > button {
-            background: linear-gradient(135deg, var(--primary), var(--primary-hover));
-            color: var(--text-on-primary);
+            background: linear-gradient(135deg, var(--primary-color), var(--secondary-color));
+            color: #fff;
             border: none;
-            border-radius: 14px;
-            padding: 0.75rem 1.45rem;
+            border-radius: 0.5rem;
+            padding: 0.4rem 1rem;
             font-weight: 600;
             font-size: var(--font-label);
             display: inline-flex;
@@ -569,15 +579,15 @@ def _inject_theme_styles() -> None:
             justify-content: center;
             gap: 0.45rem;
             letter-spacing: 0.01em;
-            box-shadow: var(--hover-glow);
+            box-shadow: 0 18px 36px -22px color-mix(in srgb, var(--primary-color) 55%, transparent);
             margin: 0.2rem 0.35rem 0.2rem 0;
         }
 
         .stButton > button:hover,
         .stDownloadButton > button:hover,
         .stFormSubmitButton > button:hover {
-            transform: translateY(-1px) scale(1.02);
-            box-shadow: 0 26px 48px -24px var(--primary-shadow);
+            transform: translateY(-1px);
+            box-shadow: 0 0 10px color-mix(in srgb, var(--primary-color) 60%, transparent);
         }
 
         .stButton > button:focus-visible,

--- a/unified_ui/theme_controller.py
+++ b/unified_ui/theme_controller.py
@@ -96,6 +96,8 @@ THEME_CONFIGS: Dict[str, Dict[str, Any]] = {
             "card-background": "#ffffff",
             "card-border": "#d9e2f1",
             "card-hover-shadow": "0 28px 60px -32px rgba(255, 107, 44, 0.35)",
+            "primary-color": "#FF6B2C",
+            "secondary-color": "#FF834D",
             "primary-gradient-start": "#FF6B2C",
             "primary-gradient-end": "#FF834D",
             "button-shadow": "0 18px 36px -20px rgba(255, 107, 44, 0.46)",
@@ -118,6 +120,8 @@ THEME_CONFIGS: Dict[str, Dict[str, Any]] = {
             "card-background": "rgba(9, 16, 32, 0.88)",
             "card-border": "rgba(120, 144, 180, 0.34)",
             "card-hover-shadow": "0 36px 72px -42px rgba(5, 10, 22, 0.92)",
+            "primary-color": "#1ABC9C",
+            "secondary-color": "#6366f1",
             "primary-gradient-start": "#1ABC9C",
             "primary-gradient-end": "#6366f1",
             "button-shadow": "0 20px 44px -28px rgba(99, 102, 241, 0.55)",
@@ -140,6 +144,8 @@ THEME_CONFIGS: Dict[str, Dict[str, Any]] = {
             "card-background": "rgba(10, 18, 40, 0.88)",
             "card-border": "rgba(120, 144, 180, 0.28)",
             "card-hover-shadow": "0 28px 64px -38px rgba(59, 130, 246, 0.48)",
+            "primary-color": "#38bdf8",
+            "secondary-color": "#9b59b6",
             "primary-gradient-start": "#38bdf8",
             "primary-gradient-end": "#9b59b6",
             "button-shadow": "0 20px 48px -30px rgba(59, 130, 246, 0.65)",
@@ -204,9 +210,15 @@ def _apply_theme_styles(theme_config: Dict[str, Any]) -> None:
             color: var(--theme-customTheme-sidebar-text);
         }}
 
-        section[data-testid="stSidebar"] p,
-        section[data-testid="stSidebar"] span,
-        section[data-testid="stSidebar"] label {{
+        /* Sidebar utility styles keep icons and labels consistently visible */
+        section[data-testid="stSidebar"] :is(svg, i) {{
+            display: inline-block !important;
+            opacity: 1 !important;
+            visibility: visible !important;
+            margin-right: 0.5rem;
+        }}
+
+        section[data-testid="stSidebar"] :is(p, span, label) {{
             color: var(--theme-customTheme-sidebar-muted);
         }}
 
@@ -352,24 +364,38 @@ def _apply_theme_styles(theme_config: Dict[str, Any]) -> None:
             box-shadow: var(--theme-customTheme-card-hover-shadow);
         }}
 
+        .btn-gradient,
         .stButton > button {{
             background: linear-gradient(
                 135deg,
-                var(--theme-customTheme-primary-gradient-start),
-                var(--theme-customTheme-primary-gradient-end)
+                var(--primary-color),
+                var(--secondary-color)
             ) !important;
-            border: 1px solid transparent !important;
-            border-radius: 0.75rem !important;
-            color: white !important;
-            font-weight: 700 !important;
-            padding: 0.85rem 1.5rem !important;
-            box-shadow: var(--theme-customTheme-button-shadow) !important;
-            transition: transform 0.25s ease, box-shadow 0.25s ease;
+            color: #fff !important;
+            border: none !important;
+            border-radius: 0.5rem !important;
+            padding: 0.4rem 1rem !important;
+            font-weight: 600 !important;
+            box-shadow: var(
+                --theme-customTheme-button-shadow,
+                0 18px 36px -22px color-mix(in srgb, var(--primary-color) 55%, transparent)
+            ) !important;
+            transition: all 0.3s ease-in-out !important;
         }}
 
+        .btn-gradient:hover,
         .stButton > button:hover {{
-            transform: translateY(-2px) !important;
-            box-shadow: var(--theme-customTheme-card-hover-shadow) !important;
+            box-shadow: 0 0 10px color-mix(in srgb, var(--primary-color) 60%, transparent) !important;
+            transform: translateY(-1px) !important;
+        }}
+
+        .fortinet-folder-monitor-block {{
+            display: flex;
+            align-items: flex-end;
+        }}
+
+        .fortinet-folder-monitor-block .stButton > button {{
+            width: 100%;
         }}
 
         .theme-config-tip {{


### PR DESCRIPTION
## Summary
- add a shared upload limit helper so Fortinet and Cisco pages pull the 2GB label from a single source
- refresh the sidebar and gradient button styling with reusable selectors while aligning the Fortinet “Use current” control via a class hook
- document the primary/secondary gradient variable mapping inside the global theme injection for easier maintenance

## Testing
- not run (UI updates only)

------
https://chatgpt.com/codex/tasks/task_e_68da386ec5d48320a79bf452435b00b6