### PR TITLE
Refactor UI routing and theming

### DIFF
--- a/cisco_ui/__init__.py
+++ b/cisco_ui/__init__.py
@@ -1,0 +1,171 @@
+"""Router for Cisco branded pages with unified navigation."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, List
+
+import streamlit as st
+
+from theme_controller import get_button_style
+
+from . import data_cleaning, log_monitor, model_inference, notifications, visualization
+
+
+@dataclass(frozen=True)
+class PageDefinition:
+    key: str
+    label: str
+    icon: str
+    description: str
+    render: Callable[[], None]
+    actions: List[Dict[str, str]]
+
+
+PAGES: List[PageDefinition] = [
+    PageDefinition(
+        key="log_monitor",
+        label="Log 擷取",
+        icon="📡",
+        description="監控 ASA log 並自動觸發清洗、推論與通知。",
+        render=log_monitor.render,
+        actions=[
+            {"label": "開啟儀表板", "type": "navigate"},
+            {"label": "開始監控", "type": "command", "command": "log_monitor:start"},
+            {"label": "停止監控", "type": "command", "command": "log_monitor:stop"},
+            {"label": "手動掃描", "type": "command", "command": "log_monitor:scan"},
+        ],
+    ),
+    PageDefinition(
+        key="data_cleaning",
+        label="資料清理",
+        icon="🧹",
+        description="維護清洗資料夾並設定排程清理策略。",
+        render=data_cleaning.render,
+        actions=[
+            {"label": "開啟頁面", "type": "navigate"},
+            {"label": "啟動排程", "type": "command", "command": "data_cleaning:start_auto"},
+            {"label": "停止排程", "type": "command", "command": "data_cleaning:stop_auto"},
+            {"label": "立即清理", "type": "command", "command": "data_cleaning:manual"},
+            {"label": "批次清空", "type": "command", "command": "data_cleaning:purge"},
+        ],
+    ),
+    PageDefinition(
+        key="model_inference",
+        label="模型推論",
+        icon="🤖",
+        description="手動載入模型與 log 檔案，執行 Pipeline。",
+        render=model_inference.render,
+        actions=[
+            {"label": "開啟頁面", "type": "navigate"},
+            {"label": "使用最新檔案", "type": "command", "command": "model_inference:use_recent"},
+            {"label": "清空上傳", "type": "command", "command": "model_inference:clear_uploads"},
+            {"label": "同步輸出路徑", "type": "command", "command": "model_inference:focus_output"},
+        ],
+    ),
+    PageDefinition(
+        key="notifications",
+        label="通知模組",
+        icon="🔔",
+        description="整合 Gemini、LINE 與 Discord 的推播設定。",
+        render=notifications.render,
+        actions=[
+            {"label": "開啟頁面", "type": "navigate"},
+            {"label": "儲存設定", "type": "command", "command": "notifications:save"},
+            {"label": "測試 LINE", "type": "command", "command": "notifications:test_line"},
+            {"label": "測試 Discord", "type": "command", "command": "notifications:test_discord"},
+        ],
+    ),
+    PageDefinition(
+        key="visualization",
+        label="圖表預覽",
+        icon="📊",
+        description="檢視最近的分析圖表並同步輸出資料夾。",
+        render=visualization.render,
+        actions=[
+            {"label": "開啟頁面", "type": "navigate"},
+            {"label": "同步路徑", "type": "command", "command": "visualization:sync"},
+            {"label": "切換圖表", "type": "command", "command": "visualization:cycle"},
+        ],
+    ),
+]
+
+
+def _ensure_state() -> None:
+    st.session_state.setdefault("cisco_current_page", PAGES[0].key)
+    st.session_state.setdefault("cisco_pending_commands", [])
+
+
+def _handle_action(page: PageDefinition, action: Dict[str, str]) -> None:
+    st.session_state["cisco_current_page"] = page.key
+    if action.get("type") == "command":
+        queue = st.session_state.setdefault("cisco_pending_commands", [])
+        queue.append({"page": page.key, "command": action["command"]})
+
+
+def _next_command(page_key: str) -> str | None:
+    queue = st.session_state.get("cisco_pending_commands", [])
+    command = None
+    remaining = []
+    for item in queue:
+        if command is None and item["page"] == page_key:
+            command = item["command"]
+        else:
+            remaining.append(item)
+    st.session_state["cisco_pending_commands"] = remaining
+    return command
+
+
+def _render_sidebar() -> None:
+    with st.sidebar:
+        st.header("📂 功能目錄")
+        st.markdown(get_button_style(), unsafe_allow_html=True)
+        for page in PAGES:
+            st.markdown(
+                f"<div class='sidebar-feature__title'>{page.icon} {page.label}</div>",
+                unsafe_allow_html=True,
+            )
+            if page.description:
+                st.markdown(
+                    f"<div class='sidebar-feature__note'>{page.description}</div>",
+                    unsafe_allow_html=True,
+                )
+            actions = page.actions
+            cols_per_row = 2
+            for start in range(0, len(actions), cols_per_row):
+                row = actions[start : start + cols_per_row]
+                cols = st.columns(len(row))
+                for col, action in zip(cols, row):
+                    if col.button(
+                        action["label"],
+                        key=f"cisco_sidebar_{page.key}_{action['label']}_{start}",
+                        use_container_width=True,
+                    ):
+                        _handle_action(page, action)
+        _render_flash_messages()
+
+
+def _render_flash_messages() -> None:
+    messages = st.session_state.pop("cisco_flash_messages", [])
+    if not messages:
+        return
+    st.markdown("---")
+    for msg in messages:
+        st.caption(msg)
+
+
+def _render_active_page() -> None:
+    key = st.session_state.get("cisco_current_page", PAGES[0].key)
+    page_lookup = {page.key: page for page in PAGES}
+    page = page_lookup.get(key, PAGES[0])
+    command = _next_command(page.key)
+    if command:
+        st.session_state[f"cisco_command_{page.key}"] = command
+    page.render()
+
+
+def render() -> None:
+    """Entry point used by :mod:`ui_app` for Cisco brand rendering."""
+
+    _ensure_state()
+    _render_sidebar()
+    _render_active_page()

--- a/cisco_ui/data_cleaning.py
+++ b/cisco_ui/data_cleaning.py
@@ -1,0 +1,79 @@
+"""Cisco data cleaning wrapper for router orchestration."""
+from __future__ import annotations
+
+from typing import Callable, Dict
+
+import streamlit as st
+
+from Cisco_ui.ui_pages import apply_dark_theme
+from Cisco_ui.ui_pages import data_cleaning as _data_cleaning
+from Cisco_ui.ui_pages import log_monitor as _log_monitor
+
+_CommandHandler = Callable[[_data_cleaning.DataCleaner], None]
+
+
+def _flash(message: str) -> None:
+    st.session_state.setdefault("cisco_flash_messages", []).append(message)
+
+
+def _current_folder() -> str:
+    monitor = _log_monitor.get_log_monitor()
+    return st.session_state.get("cisco_clean_dir", monitor.settings.get("clean_csv_dir", ""))
+
+
+def _current_retention() -> int:
+    return int(st.session_state.get("保留小時數", 3))
+
+
+def _current_interval() -> int:
+    return int(st.session_state.get("自動清理間隔（小時）", 6))
+
+
+def _start_auto(cleaner: _data_cleaning.DataCleaner) -> None:
+    cleaner.start_auto(_current_folder(), _current_retention(), _current_interval())
+    _flash("🟢 已啟動自動清理排程。")
+
+
+def _stop_auto(cleaner: _data_cleaning.DataCleaner) -> None:
+    cleaner.stop_auto()
+    _flash("⛔ 已停止自動清理排程。")
+
+
+def _manual(cleaner: _data_cleaning.DataCleaner) -> None:
+    cleaner.manual_clean(_current_folder(), _current_retention())
+    _flash("🧹 已執行一次手動清理。")
+
+
+def _batch(cleaner: _data_cleaning.DataCleaner) -> None:
+    cleaner.batch_delete(_current_folder())
+    _flash("🗑️ 已批次清除目標資料夾內的檔案。")
+
+
+def _consume_command() -> str | None:
+    return st.session_state.pop("cisco_command_data_cleaning", None)
+
+
+_HANDLERS: Dict[str, _CommandHandler] = {
+    "data_cleaning:start_auto": _start_auto,
+    "data_cleaning:stop_auto": _stop_auto,
+    "data_cleaning:manual": _manual,
+    "data_cleaning:purge": _batch,
+}
+
+
+def _dispatch(command: str | None) -> None:
+    if not command:
+        return
+    handler = _HANDLERS.get(command)
+    if not handler:
+        return
+    cleaner = _data_cleaning.get_data_cleaner()
+    handler(cleaner)
+
+
+def render() -> None:
+    """Render the Cisco data cleaning page with queued command support."""
+
+    apply_dark_theme()
+    _dispatch(_consume_command())
+    _data_cleaning.app()

--- a/cisco_ui/log_monitor.py
+++ b/cisco_ui/log_monitor.py
@@ -1,0 +1,59 @@
+"""Cisco brand log monitor wrapper with sidebar integrations."""
+from __future__ import annotations
+
+from typing import Callable, Dict
+
+import streamlit as st
+
+from Cisco_ui.ui_pages import apply_dark_theme
+from Cisco_ui.ui_pages import log_monitor as _log_monitor
+
+_CommandHandler = Callable[[_log_monitor.LogMonitor], None]
+
+
+def _flash(message: str) -> None:
+    st.session_state.setdefault("cisco_flash_messages", []).append(message)
+
+
+def _start(monitor: _log_monitor.LogMonitor) -> None:
+    monitor.start_listening()
+    _flash("🟢 已透過側邊欄啟動資料夾監控。")
+
+
+def _stop(monitor: _log_monitor.LogMonitor) -> None:
+    monitor.stop_listening()
+    _flash("⛔ 已停止資料夾監控。")
+
+
+def _scan(monitor: _log_monitor.LogMonitor) -> None:
+    monitor.scan_once()
+    _flash("🔁 已手動掃描一次監控資料夾。")
+
+
+def _consume_command() -> str | None:
+    return st.session_state.pop("cisco_command_log_monitor", None)
+
+
+_HANDLERS: Dict[str, _CommandHandler] = {
+    "log_monitor:start": _start,
+    "log_monitor:stop": _stop,
+    "log_monitor:scan": _scan,
+}
+
+
+def _dispatch(command: str | None) -> None:
+    if not command:
+        return
+    handler = _HANDLERS.get(command)
+    if not handler:
+        return
+    monitor = _log_monitor.get_log_monitor()
+    handler(monitor)
+
+
+def render() -> None:
+    """Render the Cisco log monitor page after dispatching queued commands."""
+
+    apply_dark_theme()
+    _dispatch(_consume_command())
+    _log_monitor.app()

--- a/cisco_ui/model_inference.py
+++ b/cisco_ui/model_inference.py
@@ -1,0 +1,46 @@
+"""Cisco model inference wrapper with streamlined sidebar hooks."""
+from __future__ import annotations
+
+import streamlit as st
+
+from Cisco_ui.ui_pages import apply_dark_theme
+from Cisco_ui.ui_pages import model_inference as _model_inference
+
+
+def _consume_command() -> str | None:
+    return st.session_state.pop("cisco_command_model_inference", None)
+
+
+def _dispatch(command: str | None) -> None:
+    if not command:
+        return
+    if command == "model_inference:use_recent":
+        st.session_state["cisco_use_recent_log_checkbox"] = True
+        st.session_state.setdefault("cisco_flash_messages", []).append(
+            "📁 已切換為使用最近的監控檔案。"
+        )
+    elif command == "model_inference:clear_uploads":
+        for key in [
+            "cisco_inference_log_uploader",
+            "binary_upload",
+            "multi_upload",
+        ]:
+            st.session_state.pop(key, None)
+        st.session_state.setdefault("cisco_flash_messages", []).append(
+            "🧼 已清除上傳的模型與檔案選擇。"
+        )
+    elif command == "model_inference:focus_output":
+        monitor = _model_inference.get_log_monitor()
+        target = monitor.settings.get("clean_csv_dir", "")
+        st.session_state["輸出資料夾"] = target
+        st.session_state.setdefault("cisco_flash_messages", []).append(
+            "📦 已同步輸出資料夾至自動清洗目錄。"
+        )
+
+
+def render() -> None:
+    """Render Cisco model inference page after processing sidebar commands."""
+
+    apply_dark_theme()
+    _dispatch(_consume_command())
+    _model_inference.app()

--- a/cisco_ui/notifications.py
+++ b/cisco_ui/notifications.py
@@ -1,0 +1,34 @@
+"""Cisco notification page wrapper with sidebar triggers."""
+from __future__ import annotations
+
+import streamlit as st
+
+from Cisco_ui.ui_pages import apply_dark_theme
+from Cisco_ui.ui_pages import notifications as _notifications
+
+
+def _consume_command() -> str | None:
+    return st.session_state.pop("cisco_command_notifications", None)
+
+
+def _dispatch(command: str | None) -> None:
+    if not command:
+        return
+    settings = _notifications._load_settings()
+    if command == "notifications:save":
+        _notifications._save_settings(settings)
+        st.session_state.setdefault("cisco_flash_messages", []).append("💾 已儲存通知設定。")
+    elif command == "notifications:test_line":
+        _notifications._send_line_test(settings)
+        st.session_state.setdefault("cisco_flash_messages", []).append("🟩 已透過側邊欄觸發 LINE 測試通知。")
+    elif command == "notifications:test_discord":
+        _notifications._send_discord_test(settings)
+        st.session_state.setdefault("cisco_flash_messages", []).append("💬 已透過側邊欄觸發 Discord 測試通知。")
+
+
+def render() -> None:
+    """Render Cisco notification page after consuming sidebar commands."""
+
+    apply_dark_theme()
+    _dispatch(_consume_command())
+    _notifications.app()

--- a/cisco_ui/visualization.py
+++ b/cisco_ui/visualization.py
@@ -1,0 +1,40 @@
+"""Cisco visualization wrapper used by the router."""
+from __future__ import annotations
+
+import itertools
+
+import streamlit as st
+
+from Cisco_ui.ui_pages import apply_dark_theme
+from Cisco_ui.ui_pages import visualization as _visualization
+from Cisco_ui.ui_pages.log_monitor import get_log_monitor
+
+
+def _consume_command() -> str | None:
+    return st.session_state.pop("cisco_command_visualization", None)
+
+
+def _dispatch(command: str | None) -> None:
+    if not command:
+        return
+    if command == "visualization:sync":
+        monitor = get_log_monitor()
+        st.session_state["cisco_visual_folder"] = monitor.settings.get("clean_csv_dir", "")
+        st.session_state.setdefault("cisco_flash_messages", []).append("📂 已同步圖表資料夾位置。")
+    elif command == "visualization:cycle":
+        buttons = list(_visualization.CHART_FILES.keys())
+        current = st.session_state.get("cisco_visual_selected", buttons[0])
+        cycle = itertools.cycle(buttons)
+        for label in cycle:
+            if label == current:
+                st.session_state["cisco_visual_selected"] = next(cycle)
+                break
+        st.session_state.setdefault("cisco_flash_messages", []).append("🔄 已切換到下一個圖表。")
+
+
+def render() -> None:
+    """Render the Cisco visualization page."""
+
+    apply_dark_theme()
+    _dispatch(_consume_command())
+    _visualization.app()

--- a/fortinet_ui/__init__.py
+++ b/fortinet_ui/__init__.py
@@ -1,0 +1,169 @@
+"""Router for Fortinet branded pages with the new navigation pattern."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, List
+
+import streamlit as st
+
+from theme_controller import get_button_style
+
+from . import data_cleaning, log_monitor, model_inference, notifications, visualization
+
+
+@dataclass(frozen=True)
+class PageDefinition:
+    key: str
+    label: str
+    icon: str
+    description: str
+    render: Callable[[], None]
+    actions: List[Dict[str, str]]
+
+
+PAGES: List[PageDefinition] = [
+    PageDefinition(
+        key="log_monitor",
+        label="資料夾監控",
+        icon="📂",
+        description="自動監控資料夾、執行 ETL 與推播告警。",
+        render=log_monitor.render,
+        actions=[
+            {"label": "開啟頁面", "type": "navigate"},
+            {"label": "使用目前目錄", "type": "command", "command": "log_monitor:use_cwd"},
+            {"label": "清除暫存", "type": "command", "command": "log_monitor:clear_generated"},
+        ],
+    ),
+    PageDefinition(
+        key="data_cleaning",
+        label="GPU ETL",
+        icon="🚀",
+        description="批次清理、映射與特徵工程的 GPU 加速流程。",
+        render=data_cleaning.render,
+        actions=[
+            {"label": "開啟頁面", "type": "navigate"},
+            {"label": "全選步驟", "type": "command", "command": "data_cleaning:select_all"},
+            {"label": "全部停用", "type": "command", "command": "data_cleaning:clear_all"},
+            {"label": "預設輸出名", "type": "command", "command": "data_cleaning:reset_output"},
+        ],
+    ),
+    PageDefinition(
+        key="model_inference",
+        label="模型推論",
+        icon="🧠",
+        description="上傳資料與模型，執行二元/多元推論流程。",
+        render=model_inference.render,
+        actions=[
+            {"label": "開啟頁面", "type": "navigate"},
+            {"label": "清除上傳", "type": "command", "command": "model_inference:reset_inputs"},
+            {"label": "清除結果", "type": "command", "command": "model_inference:clear_results"},
+            {"label": "準備重新上傳", "type": "command", "command": "model_inference:prefill"},
+        ],
+    ),
+    PageDefinition(
+        key="notifications",
+        label="通知模組",
+        icon="🔔",
+        description="設定 Discord / LINE / Gemini 告警並快速測試。",
+        render=notifications.render,
+        actions=[
+            {"label": "開啟頁面", "type": "navigate"},
+            {"label": "清空欄位", "type": "command", "command": "notifications:reset_fields"},
+            {"label": "測試 Discord", "type": "command", "command": "notifications:test_discord"},
+            {"label": "測試 LINE", "type": "command", "command": "notifications:test_line"},
+            {"label": "預覽報表", "type": "command", "command": "notifications:preview"},
+        ],
+    ),
+    PageDefinition(
+        key="visualization",
+        label="視覺化分析",
+        icon="📈",
+        description="檢視分析圖表並重置暫存資料。",
+        render=visualization.render,
+        actions=[
+            {"label": "開啟頁面", "type": "navigate"},
+            {"label": "清除暫存", "type": "command", "command": "visualization:clear_cache"},
+            {"label": "提示最新報表", "type": "command", "command": "visualization:load_latest"},
+        ],
+    ),
+]
+
+
+def _ensure_state() -> None:
+    st.session_state.setdefault("fortinet_current_page", PAGES[0].key)
+    st.session_state.setdefault("fortinet_pending_commands", [])
+
+
+def _handle_action(page: PageDefinition, action: Dict[str, str]) -> None:
+    st.session_state["fortinet_current_page"] = page.key
+    if action.get("type") == "command":
+        queue = st.session_state.setdefault("fortinet_pending_commands", [])
+        queue.append({"page": page.key, "command": action["command"]})
+
+
+def _next_command(page_key: str) -> str | None:
+    queue = st.session_state.get("fortinet_pending_commands", [])
+    command = None
+    remaining = []
+    for item in queue:
+        if command is None and item["page"] == page_key:
+            command = item["command"]
+        else:
+            remaining.append(item)
+    st.session_state["fortinet_pending_commands"] = remaining
+    return command
+
+
+def _render_sidebar() -> None:
+    with st.sidebar:
+        st.header("📂 功能目錄")
+        st.markdown(get_button_style(), unsafe_allow_html=True)
+        for page in PAGES:
+            st.markdown(
+                f"<div class='sidebar-feature__title'>{page.icon} {page.label}</div>",
+                unsafe_allow_html=True,
+            )
+            if page.description:
+                st.markdown(
+                    f"<div class='sidebar-feature__note'>{page.description}</div>",
+                    unsafe_allow_html=True,
+                )
+            cols_per_row = 2
+            for start in range(0, len(page.actions), cols_per_row):
+                row = page.actions[start : start + cols_per_row]
+                cols = st.columns(len(row))
+                for col, action in zip(cols, row):
+                    if col.button(
+                        action["label"],
+                        key=f"fortinet_sidebar_{page.key}_{action['label']}_{start}",
+                        use_container_width=True,
+                    ):
+                        _handle_action(page, action)
+        _render_flash_messages()
+
+
+def _render_flash_messages() -> None:
+    messages = st.session_state.pop("fortinet_flash_messages", [])
+    if not messages:
+        return
+    st.markdown("---")
+    for msg in messages:
+        st.caption(msg)
+
+
+def _render_active_page() -> None:
+    key = st.session_state.get("fortinet_current_page", PAGES[0].key)
+    page_lookup = {page.key: page for page in PAGES}
+    page = page_lookup.get(key, PAGES[0])
+    command = _next_command(page.key)
+    if command:
+        st.session_state[f"fortinet_command_{page.key}"] = command
+    page.render()
+
+
+def render() -> None:
+    """Entry point invoked by ``ui_app`` to render Fortinet brand UI."""
+
+    _ensure_state()
+    _render_sidebar()
+    _render_active_page()

--- a/fortinet_ui/data_cleaning.py
+++ b/fortinet_ui/data_cleaning.py
@@ -1,0 +1,42 @@
+"""Fortinet GPU ETL wrapper to fit the new router contract."""
+from __future__ import annotations
+
+import streamlit as st
+
+from Forti_ui_app_bundle.ui_pages import apply_dark_theme
+from Forti_ui_app_bundle.ui_pages import gpu_etl_ui as _gpu_etl
+
+
+_CHECKBOX_KEYS = ["Run cleaning", "Run mapping", "Run feature engineering"]
+
+
+def _consume_command() -> str | None:
+    return st.session_state.pop("fortinet_command_data_cleaning", None)
+
+
+def _flash(message: str) -> None:
+    st.session_state.setdefault("fortinet_flash_messages", []).append(message)
+
+
+def _dispatch(command: str | None) -> None:
+    if not command:
+        return
+    if command == "data_cleaning:select_all":
+        for key in _CHECKBOX_KEYS:
+            st.session_state[key] = True
+        _flash("✅ 已開啟所有 ETL 步驟。")
+    elif command == "data_cleaning:clear_all":
+        for key in _CHECKBOX_KEYS:
+            st.session_state[key] = False
+        _flash("🚫 已停用所有 ETL 步驟。")
+    elif command == "data_cleaning:reset_output":
+        st.session_state["Output CSV path"] = "engineered_data.csv"
+        _flash("📄 已重設輸出檔名為預設值。")
+
+
+def render() -> None:
+    """Render Fortinet GPU ETL page with sidebar automation hooks."""
+
+    apply_dark_theme()
+    _dispatch(_consume_command())
+    _gpu_etl.app()

--- a/fortinet_ui/log_monitor.py
+++ b/fortinet_ui/log_monitor.py
@@ -1,0 +1,36 @@
+"""Fortinet folder monitor wrapper for unified router usage."""
+from __future__ import annotations
+
+import os
+
+import streamlit as st
+
+from Forti_ui_app_bundle.ui_pages import apply_dark_theme
+from Forti_ui_app_bundle.ui_pages import folder_monitor_ui as _folder_monitor
+
+
+def _consume_command() -> str | None:
+    return st.session_state.pop("fortinet_command_log_monitor", None)
+
+
+def _flash(message: str) -> None:
+    st.session_state.setdefault("fortinet_flash_messages", []).append(message)
+
+
+def _dispatch(command: str | None) -> None:
+    if not command:
+        return
+    if command == "log_monitor:use_cwd":
+        st.session_state["folder_input"] = os.getcwd()
+        _flash("📁 已改為監控目前工作目錄。")
+    elif command == "log_monitor:clear_generated":
+        _folder_monitor._cleanup_generated(0, force=True)
+        _flash("🧹 已清除所有暫存輸出檔案。")
+
+
+def render() -> None:
+    """Render Fortinet folder monitor page with command hooks."""
+
+    apply_dark_theme()
+    _dispatch(_consume_command())
+    _folder_monitor.app()

--- a/fortinet_ui/model_inference.py
+++ b/fortinet_ui/model_inference.py
@@ -1,0 +1,43 @@
+"""Fortinet model inference wrapper to support router commands."""
+from __future__ import annotations
+
+import streamlit as st
+
+from Forti_ui_app_bundle.ui_pages import apply_dark_theme
+from Forti_ui_app_bundle.ui_pages import inference_ui as _inference
+
+_UPLOAD_KEYS = ["Upload data CSV", "Upload binary model", "Upload multiclass model"]
+
+
+def _consume_command() -> str | None:
+    return st.session_state.pop("fortinet_command_model_inference", None)
+
+
+def _flash(message: str) -> None:
+    st.session_state.setdefault("fortinet_flash_messages", []).append(message)
+
+
+def _dispatch(command: str | None) -> None:
+    if not command:
+        return
+    if command == "model_inference:reset_inputs":
+        for key in _UPLOAD_KEYS:
+            st.session_state.pop(key, None)
+        st.session_state.pop("prediction_results", None)
+        _flash("🧹 已清除上傳的資料與模型。")
+    elif command == "model_inference:clear_results":
+        st.session_state.pop("prediction_results", None)
+        _flash("🗑️ 已移除先前的推論結果。")
+    elif command == "model_inference:prefill":
+        st.session_state["Upload data CSV"] = None
+        st.session_state["Upload binary model"] = None
+        st.session_state["Upload multiclass model"] = None
+        _flash("📄 請上傳新的資料與模型檔案。")
+
+
+def render() -> None:
+    """Render Fortinet inference page with sidebar automation hooks."""
+
+    apply_dark_theme()
+    _dispatch(_consume_command())
+    _inference.app()

--- a/fortinet_ui/notifications.py
+++ b/fortinet_ui/notifications.py
@@ -1,0 +1,64 @@
+"""Fortinet notification wrapper compatible with the router."""
+from __future__ import annotations
+
+import streamlit as st
+
+from Forti_ui_app_bundle.notifier import notify_from_csv, send_discord, send_line_to_all
+from Forti_ui_app_bundle.ui_pages import apply_dark_theme
+from Forti_ui_app_bundle.ui_pages import notifier_app as _notifier_app
+
+
+def _consume_command() -> str | None:
+    return st.session_state.pop("fortinet_command_notifications", None)
+
+
+def _flash(message: str) -> None:
+    st.session_state.setdefault("fortinet_flash_messages", []).append(message)
+
+
+def _dispatch(command: str | None) -> None:
+    if not command:
+        return
+    if command == "notifications:reset_fields":
+        for key in ["discord_webhook", "gemini_key", "line_token"]:
+            st.session_state[key] = ""
+        _flash("🧽 已清空通知設定欄位。")
+    elif command == "notifications:test_discord":
+        url = st.session_state.get("discord_webhook", "")
+        if url:
+            ok, info = send_discord(url, "This is a test notification from D-FLARE.")
+            _flash("💬 Discord 測試成功。" if ok else f"⚠️ Discord 測試失敗：{info}")
+        else:
+            _flash("⚠️ 尚未設定 Discord Webhook URL。")
+    elif command == "notifications:test_line":
+        token = st.session_state.get("line_token", "")
+        if token:
+            ok = send_line_to_all(token, "This is a test notification from D-FLARE.")
+            _flash("🟩 LINE 測試成功。" if ok else "⚠️ LINE 測試失敗。")
+        else:
+            _flash("⚠️ 尚未設定 LINE Channel Access Token。")
+    elif command == "notifications:preview":
+        csv_path = st.session_state.get("last_report_path")
+        if csv_path:
+            results = notify_from_csv(
+                csv_path,
+                st.session_state.get("discord_webhook", ""),
+                st.session_state.get("gemini_key", ""),
+                risk_levels={"3", "4"},
+                ui_log=lambda msg: None,
+                dedupe_cache=st.session_state.get("dedupe_cache"),
+                line_token=st.session_state.get("line_token", ""),
+                convergence=st.session_state.get("forti_convergence"),
+            )
+            success = sum(1 for _, ok, _ in results if ok)
+            _flash(f"🔔 已預覽最近報表，共 {success} 則通知。")
+        else:
+            _flash("ℹ️ 尚未產生報表，可先於 Folder Monitor 執行分析。")
+
+
+def render() -> None:
+    """Render the Fortinet notification page with sidebar commands."""
+
+    apply_dark_theme()
+    _dispatch(_consume_command())
+    _notifier_app.app()

--- a/fortinet_ui/visualization.py
+++ b/fortinet_ui/visualization.py
@@ -1,0 +1,38 @@
+"""Fortinet visualization wrapper for unified routing."""
+from __future__ import annotations
+
+import streamlit as st
+
+from Forti_ui_app_bundle.ui_pages import apply_dark_theme
+from Forti_ui_app_bundle.ui_pages import visualization_ui as _visualization
+
+
+def _consume_command() -> str | None:
+    return st.session_state.pop("fortinet_command_visualization", None)
+
+
+def _flash(message: str) -> None:
+    st.session_state.setdefault("fortinet_flash_messages", []).append(message)
+
+
+def _dispatch(command: str | None) -> None:
+    if not command:
+        return
+    if command == "visualization:clear_cache":
+        st.session_state.pop("last_counts", None)
+        st.session_state.pop("last_report_path", None)
+        _flash("♻️ 已清除暫存的圖表資料。")
+    elif command == "visualization:load_latest":
+        report = st.session_state.get("last_report_path")
+        if report:
+            _flash(f"📊 目前檢視報表：{report}")
+        else:
+            _flash("ℹ️ 尚未產生報表，可先於 Folder Monitor 執行分析。")
+
+
+def render() -> None:
+    """Render the Fortinet visualization module."""
+
+    apply_dark_theme()
+    _dispatch(_consume_command())
+    _visualization.app()

--- a/theme_controller.py
+++ b/theme_controller.py
@@ -1,0 +1,150 @@
+"""Global theme controller for the unified D-FLARE UI."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+import streamlit as st
+
+
+@dataclass(frozen=True)
+class ThemePalette:
+    """Simple representation of a sidebar/button palette."""
+
+    label: str
+    start: str
+    end: str
+    text: str
+    shadow: str
+    sidebar_bg: str
+    sidebar_text: str
+    sidebar_border: str
+    hover: str
+
+
+THEMES: Dict[str, ThemePalette] = {
+    "gradient-blue": ThemePalette(
+        label="Gradient Blue",
+        start="#38bdf8",
+        end="#6366f1",
+        text="#ffffff",
+        shadow="0 22px 40px -22px rgba(99, 102, 241, 0.55)",
+        sidebar_bg="#0f172a",
+        sidebar_text="#e2e8f0",
+        sidebar_border="rgba(148, 163, 184, 0.25)",
+        hover="rgba(37, 99, 235, 0.15)",
+    ),
+    "gradient-red": ThemePalette(
+        label="Gradient Red",
+        start="#fb7185",
+        end="#f97316",
+        text="#ffffff",
+        shadow="0 22px 40px -22px rgba(249, 115, 22, 0.55)",
+        sidebar_bg="#1f0f17",
+        sidebar_text="#f1f5f9",
+        sidebar_border="rgba(248, 113, 113, 0.25)",
+        hover="rgba(249, 115, 22, 0.18)",
+    ),
+    "glow-green": ThemePalette(
+        label="Glow Green",
+        start="#2dd4bf",
+        end="#16a34a",
+        text="#042f2e",
+        shadow="0 22px 40px -22px rgba(34, 197, 94, 0.45)",
+        sidebar_bg="#052e16",
+        sidebar_text="#ecfdf5",
+        sidebar_border="rgba(16, 185, 129, 0.28)",
+        hover="rgba(16, 185, 129, 0.22)",
+    ),
+}
+
+_DEFAULT_THEME = "gradient-blue"
+
+
+def available_themes() -> Dict[str, str]:
+    """Return mapping of theme key to display label."""
+
+    return {key: palette.label for key, palette in THEMES.items()}
+
+
+def apply_theme(theme: str | None = None) -> None:
+    """Persist the chosen theme in session state and inject base styling."""
+
+    theme_key = theme or st.session_state.get("active_theme", _DEFAULT_THEME)
+    if theme_key not in THEMES:
+        theme_key = _DEFAULT_THEME
+
+    st.session_state["active_theme"] = theme_key
+    palette = THEMES[theme_key]
+
+    st.markdown(
+        f"""
+        <style>
+        :root {{
+            --df-sidebar-bg: {palette.sidebar_bg};
+            --df-sidebar-text: {palette.sidebar_text};
+            --df-sidebar-border: {palette.sidebar_border};
+            --df-sidebar-hover: {palette.hover};
+            --df-button-start: {palette.start};
+            --df-button-end: {palette.end};
+            --df-button-text: {palette.text};
+            --df-button-shadow: {palette.shadow};
+        }}
+        div[data-testid="stSidebar"] {{
+            background: var(--df-sidebar-bg);
+            color: var(--df-sidebar-text);
+        }}
+        div[data-testid="stSidebar"] .sidebar-feature__title {{
+            color: var(--df-sidebar-text);
+            font-weight: 600;
+            letter-spacing: 0.02em;
+        }}
+        div[data-testid="stSidebar"] hr {{
+            border-color: var(--df-sidebar-border) !important;
+        }}
+        div[data-testid="stSidebar"] .sidebar-feature__actions {{
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+            gap: 0.35rem;
+            margin-bottom: 0.75rem;
+        }}
+        div[data-testid="stSidebar"] .sidebar-feature__actions div.stButton > button,
+        div[data-testid="stSidebar"] div.stButton > button {{
+            background: linear-gradient(135deg, var(--df-button-start), var(--df-button-end));
+            color: var(--df-button-text) !important;
+            border: none;
+            border-radius: 12px;
+            font-size: 0.85rem;
+            font-weight: 600;
+            box-shadow: var(--df-button-shadow);
+            transition: transform 0.18s ease, box-shadow 0.18s ease;
+            padding: 0.45rem 0.6rem;
+        }}
+        div[data-testid="stSidebar"] .sidebar-feature__actions div.stButton > button:hover,
+        div[data-testid="stSidebar"] div.stButton > button:hover {{
+            transform: translateY(-1px);
+            box-shadow: 0 18px 30px -18px var(--df-button-start, rgba(15, 118, 110, 0.45));
+        }}
+        div[data-testid="stSidebar"] .sidebar-feature__note {{
+            color: color-mix(in srgb, var(--df-sidebar-text), #94a3b8 45%);
+            font-size: 0.78rem;
+            margin-bottom: 0.75rem;
+        }}
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def get_button_style() -> str:
+    """Return CSS snippet ensuring sidebar buttons use the active palette."""
+
+    palette = THEMES[st.session_state.get("active_theme", _DEFAULT_THEME)]
+    return (
+        "<style>"
+        "div[data-testid=\"stSidebar\"] div.stButton > button {"
+        f"background: linear-gradient(135deg, {palette.start}, {palette.end});"
+        f"color: {palette.text} !important;"
+        "}"
+        "</style>"
+    )

--- a/ui_app.py
+++ b/ui_app.py
@@ -1,0 +1,75 @@
+"""Unified Streamlit entry point that routes to brand-specific UIs."""
+from __future__ import annotations
+
+from typing import Callable, Dict
+
+import streamlit as st
+from streamlit.delta_generator import DeltaGenerator
+
+import cisco_ui
+import fortinet_ui
+from theme_controller import apply_theme, available_themes
+
+BRAND_ROUTERS: Dict[str, Callable[[], None]] = {
+    "Fortinet": fortinet_ui.render,
+    "Cisco": cisco_ui.render,
+}
+
+BRAND_ICONS = {"Fortinet": "🛡️", "Cisco": "📡"}
+BRAND_DESCRIPTIONS = {
+    "Fortinet": "整合訓練、GPU ETL、推論與通知的 Fortinet 品牌控制台。",
+    "Cisco": "專注 ASA log 擷取與推論的 Cisco 品牌控制台。",
+}
+
+
+def _select_brand(container: DeltaGenerator) -> str:
+    options = list(BRAND_ROUTERS.keys())
+    default = st.session_state.get("selected_brand", options[0])
+    index = options.index(default) if default in options else 0
+    with container:
+        brand = st.selectbox(
+            "選擇品牌",
+            options,
+            index=index,
+            format_func=lambda x: f"{BRAND_ICONS[x]} {x}",
+        )
+    st.session_state["selected_brand"] = brand
+    return brand
+
+
+def _select_theme(container: DeltaGenerator) -> str:
+    themes = available_themes()
+    keys = list(themes.keys())
+    default = st.session_state.get("active_theme", keys[0])
+    index = keys.index(default) if default in keys else 0
+    with container:
+        theme = st.selectbox(
+            "按鈕主題",
+            keys,
+            index=index,
+            format_func=lambda key: themes[key],
+        )
+    return theme
+
+
+def main() -> None:
+    """Streamlit app entry point used by ``streamlit run ui_app.py``."""
+
+    st.set_page_config(page_title="D-FLARE Unified Dashboard", page_icon="🛡️", layout="wide")
+
+    st.sidebar.image("LOGO.png", use_column_width=True)
+
+    brand_col, theme_col = st.columns([1, 1])
+    brand = _select_brand(brand_col)
+    theme_key = _select_theme(theme_col)
+    apply_theme(theme_key)
+
+    icon = BRAND_ICONS.get(brand, "🛡️")
+    st.title(f"{icon} {brand} D-FLARE 控制台")
+    st.caption(BRAND_DESCRIPTIONS.get(brand, ""))
+
+    BRAND_ROUTERS[brand]()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a central `theme_controller` with selectable button palettes
- wrap the existing Cisco and Fortinet pages in brand-specific routers that render the new sidebar menu
- expose a unified `ui_app.py` entry point that lets operators switch brand and theme at runtime

## Testing
- `python -m compileall ui_app.py theme_controller.py cisco_ui fortinet_ui`


------
https://chatgpt.com/codex/tasks/task_e_68daacc59cc48320a0459ccf03d6a6db